### PR TITLE
Modify source file for updated databricks support

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -54,6 +54,10 @@ vars:
     snowplow__incremental_materialization: "snowplow_incremental"
     snowplow__dev_target_name: 'dev'
     snowplow__allow_refresh: false
+    # Variables - Databricks Only
+    # Add the following variable to your dbt project's dbt_project.yml file
+    # Depending on the use case it should either be the catalog (for Unity Catalog users from databricks connector 1.1.1 onwards) or the same value as your snowplow__atomic_schema (unless changed it should be 'atomic')
+    # snowplow__databricks_catalog: 'hive_metastore'
 
 
 

--- a/docs/markdown/snowplow_web_overview.md
+++ b/docs/markdown/snowplow_web_overview.md
@@ -105,6 +105,19 @@ vars:
     snowplow__heartbeat: 10 # Default value
 ```
 
+### 5 - Databricks only - setting the databricks_catalog
+
+Add the following variable to your dbt project's `dbt_project.yml` file
+
+```yml
+# dbt_project.yml
+...
+vars:
+  snowplow_web:
+    snowplow__databricks_catalog: 'hive_metastore'
+```
+Depending on the use case it should either be the catalog (for Unity Catalog users from databricks connector 1.1.1 onwards, defaulted to 'hive_metastore') or the same value as your `snowplow__atomic_schema` (unless changed it should be 'atomic'). This is needed to handle the database property within models/base/src_base.yml.
+
 ## Configuration
 
 ### Output Schemas

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -45,7 +45,7 @@ vars:
     snowplow__page_view_context: "{{ ref('snowplow_web_page_view_context_stg') }}"
     snowplow__start_date: "2020-07-03"
     snowplow__backfill_limit_days: 2
-
+    snowplow__databricks_catalog: 'atomic'
 
 seeds:
   quote_columns: false

--- a/models/base/src_base.yml
+++ b/models/base/src_base.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: atomic
     schema: "{{ var('snowplow__atomic_schema', 'atomic') }}"
-    database: "{{ var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__atomic_schema', 'atomic') }}"
+    database: "{{ var('snowplow__database', target.database) if target.type not in ['databricks', 'spark'] else var('snowplow__databricks_catalog', 'hive_metastore') }}"
     tables:
       - name: com_snowplowanalytics_snowplow_web_page_1
         description: '{{ doc("table_page_view_context") }}'


### PR DESCRIPTION
## Description & motivation
Added the new variable `snowplow__databricks_catalog` for users to add to their own project and make it flexible for different use cases:
1. for users with databricks adapter  v1.1.1 onwards: adding their catalog
2. for current users: adding the same value as their `snowplow__atomic_schema`

This needs to be done to avoid the `Cannot set database in spark!` error message that is most likely due to this dbt bug: https://github.com/dbt-labs/dbt-core/issues/3698
