### PR TITLE
Feature/custom example expansion

### DIFF
--- a/custom_example/README.md
+++ b/custom_example/README.md
@@ -36,7 +36,7 @@ This method takes your custom SQL and produces an incremental 'derived' custom t
 
 Another advantage of this method is if you want to change the logic in your custom module and replay all events through the new version, you don't have to also tear down the 'standard' table with corresponding level of aggregation  as the two are independent.
 
-An example of such a set up can be seen in [snowplow_web_pv_channel_engagement.sql](models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/snowplow_web_pv_channel_engagement.sql). This model calculates page view engagement by channel by using metrics derived from link click events.
+An example of such a set up for Redshift can be seen in [snowplow_web_pv_channel_engagement.sql](models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/default/snowplow_web_pv_channel_engagement.sql). This model calculates page view engagement by channel by using metrics derived from link click events. Similar examples for BigQuery, Snowflake and Databricks can be found under [page_view_channel_engagement](models/snowplow_web_custom_modules/page_views/page_view_channel_engagement).
 
 ### Points to note
 

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/bigquery/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/bigquery/snowplow_web_pv_channel_engagement.sql
@@ -1,0 +1,89 @@
+--Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+
+{{ 
+  config(
+    materialized='snowplow_incremental',
+    unique_key='page_view_id',
+    upsert_date_key='start_tstamp',
+    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+      "field": "start_tstamp",
+      "data_type": "timestamp"
+    }),
+  ) 
+}}
+
+with link_clicks as (
+  select distinct
+    ev.page_view_id,
+
+    count(ev.event_id)
+      over(partition by ev.page_view_id
+      order by ev.derived_tstamp desc
+      rows between unbounded preceding and unbounded following)
+      as link_clicks,
+
+    first_value(ev.unstruct_event_com_snowplowanalytics_snowplow_link_click_1_0_1.target_url)
+      over(partition by ev.page_view_id
+      order by ev.derived_tstamp desc
+      rows between unbounded preceding and unbounded following)
+      as first_link_target
+
+  from {{ ref('snowplow_web_base_events_this_run' ) }} ev -- Select events from base_events_this_run rather than raw events table
+
+  where
+    {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+    and ev.unstruct_event_com_snowplowanalytics_snowplow_link_click_1_0_1.target_url is not null -- only include link click events
+)
+
+, engagement as (
+  select
+    pv.page_view_id,
+    pv.start_tstamp,
+    case
+      when pv.refr_medium = 'search'
+       and (regexp_contains(lower(pv.mkt_medium), '(cpc|ppc|sem|paidsearch)')
+         or regexp_contains(lower(pv.mkt_source), '(cpc|ppc|sem|paidsearch)')) then 'paidsearch'
+      when lower(pv.mkt_medium) like '%paidsearch%'
+       or lower(pv.mkt_source) like '%paidsearch%' then 'paidsearch'
+      when regexp_contains(lower(pv.mkt_source), '(adwords|google_paid|googleads)')
+       or regexp_contains(lower(pv.mkt_medium), '(adwords|google_paid|googleads)') then 'paidsearch'
+      when lower(pv.mkt_source) like '%google%'
+       and lower(pv.mkt_medium) like '%ads%' then 'paidsearch'
+      when pv.refr_urlhost in ('www.googleadservices.com','googleads.g.doubleclick.net') then 'paidsearch'
+      when regexp_contains(lower(pv.mkt_medium), '(cpv|cpa|cpp|content-text|advertising|ads)') then 'advertising'
+      when regexp_contains(lower(pv.mkt_medium), '(display|cpm|banner)') then 'display'
+      when pv.refr_medium is null and lower(pv.page_url) not like '%utm_%' then 'direct'
+      when (lower(pv.refr_medium) = 'search' and pv.mkt_medium is null)
+       or (lower(pv.refr_medium) = 'search' and lower(pv.mkt_medium) = 'organic') then 'organicsearch'
+      when pv.refr_medium = 'social'
+       or regexp_contains(lower(pv.mkt_source), '^((.*(facebook|linkedin|instagram|insta|slideshare|social|tweet|twitter|youtube|lnkd|pinterest|googleplus|instagram|plus.google.com|quora|reddit|t.co|twitch|viadeo|xing|youtube).*)|(yt|fb|li))$')
+       or regexp_contains(lower(pv.mkt_medium), '^(.*)(social|facebook|linkedin|twitter|instagram|tweet)(.*)$') then 'social'
+      when pv.refr_medium = 'email'
+       or lower(pv.mkt_medium) = '_mail' then 'email'
+      when lower(pv.mkt_medium) = 'affiliate' then 'affiliate'
+      when pv.refr_medium = 'unknown' or lower(pv.mkt_medium) = 'referral' or lower(pv.mkt_medium) = 'referal' then 'referral'
+      when pv.refr_medium = 'internal' then 'internal'
+      else 'others'
+    end as channel,
+    case
+      when pv.engaged_time_in_s = 0 then true
+      else false
+    end as is_bounced_page_view,
+    (pv.vertical_percentage_scrolled / 100) * 0.3 + (pv.engaged_time_in_s / 600) * 0.7 as engagement_score
+
+  from {{ ref('snowplow_web_page_views_this_run' ) }} pv --select from page_views_this_run rather than derived page_views table
+  where {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+)
+
+select
+  eng.page_view_id,
+  eng.start_tstamp,
+  lc.link_clicks,
+  lc.first_link_target,
+  eng.is_bounced_page_view,
+  eng.engagement_score,
+  eng.channel
+
+from engagement eng
+left join link_clicks lc
+on eng.page_view_id = lc.page_view_id

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/channel_engagement.yml
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/channel_engagement.yml
@@ -18,3 +18,11 @@ models:
         description: Was the page view a bounce visit
       - name: engagement_score
         description: Engagement score based on time engaged and vertical scrolling
+      - name: channel
+        description: Rule based groupings of traffic sources and mediums
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['search', 'paidsearch', 'advertising', 'display', 'direct', 
+                'organicsearch', 'social', 'email', 'affiliate', 'referral', 'internal', 
+                'others']

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/databricks/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/databricks/snowplow_web_pv_channel_engagement.sql
@@ -5,13 +5,12 @@
     materialized='snowplow_incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
-    sort='start_tstamp',
-    dist='page_view_id'
+    partition_by = snowplow_utils.get_partition_by(databricks_partition_by='start_tstamp_date')
   ) 
 }}
 
 with link_clicks as (
-  select
+  select distinct
     ev.page_view_id,
 
     count(ev.event_id)
@@ -20,21 +19,17 @@ with link_clicks as (
       rows between unbounded preceding and unbounded following)
       as link_clicks,
 
-    first_value(lc.target_url)
+    first_value(ev.unstruct_event_com_snowplowanalytics_snowplow_link_click_1.target_url)
       over(partition by ev.page_view_id
       order by ev.derived_tstamp desc
       rows between unbounded preceding and unbounded following)
       as first_link_target
 
-  from {{ source('atomic','com_snowplowanalytics_snowplow_link_click_1') }} lc
-
-  inner join {{ ref('snowplow_web_base_events_this_run' ) }} ev -- Select events from base_events_this_run rather than raw events table
-  on lc.root_id = ev.event_id and lc.root_tstamp = ev.collector_tstamp
+  from {{ ref('snowplow_web_base_events_this_run' ) }} ev -- Select events from base_events_this_run rather than raw events table
 
   where
-    lc.root_tstamp >= (select lower_limit from {{ ref('snowplow_web_base_new_event_limits') }}) -- limit link clicks table scan using the base_new_event_limits table
-    and lc.root_tstamp <= (select upper_limit from {{ ref('snowplow_web_base_new_event_limits') }})
-    and {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+    {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+    and ev.unstruct_event_com_snowplowanalytics_snowplow_link_click_1 is not null -- only include link click events
 )
 
 , engagement as (
@@ -43,27 +38,27 @@ with link_clicks as (
     pv.start_tstamp,
     case
       when pv.refr_medium = 'search'
-       and (lower(pv.mkt_medium) similar to '%(cpc|ppc|sem|paidsearch)%'
-         or lower(pv.mkt_source) similar to '%(cpc|ppc|sem|paidsearch)%') then 'paidsearch'
-      when lower(pv.mkt_medium) ilike '%paidsearch%'
-       or lower(pv.mkt_source) ilike '%paidsearch%' then 'paidsearch'
-      when lower(pv.mkt_source) similar to '%(adwords|google_paid|googleads)%'
-       or lower(pv.mkt_medium) similar to '%(adwords|google_paid|googleads)%' then 'paidsearch'
+       and (rlike(lower(pv.mkt_medium), '(cpc|ppc|sem|paidsearch)')
+         or rlike(lower(pv.mkt_source), '(cpc|ppc|sem|paidsearch)')) then 'paidsearch'
+      when pv.mkt_medium ilike '%paidsearch%'
+       or pv.mkt_source ilike '%paidsearch%' then 'paidsearch'
+      when rlike(lower(pv.mkt_source), '(adwords|google_paid|googleads)')
+       or rlike(lower(pv.mkt_medium), '(adwords|google_paid|googleads)') then 'paidsearch'
       when pv.mkt_source ilike '%google%'
        and pv.mkt_medium ilike '%ads%' then 'paidsearch'
       when pv.refr_urlhost in ('www.googleadservices.com','googleads.g.doubleclick.net') then 'paidsearch'
-      when lower(pv.mkt_medium) similar to '%(cpv|cpa|cpp|content-text|advertising|ads)%' then 'advertising'
-      when lower(pv.mkt_medium) similar to '%(display|cpm|banner)%' then 'display'
+      when rlike(lower(pv.mkt_medium), '(cpv|cpa|cpp|content-text|advertising|ads)') then 'advertising'
+      when rlike(lower(pv.mkt_medium), '(display|cpm|banner)') then 'display'
       when pv.refr_medium is null and pv.page_url not ilike '%utm_%' then 'direct'
       when (lower(pv.refr_medium) = 'search' and pv.mkt_medium is null)
        or (lower(pv.refr_medium) = 'search' and lower(pv.mkt_medium) = 'organic') then 'organicsearch'
       when pv.refr_medium = 'social'
-       or regexp_count(lower(pv.mkt_source),'^((.*(facebook|linkedin|instagram|insta|slideshare|social|tweet|twitter|youtube|lnkd|pinterest|googleplus|instagram|plus.google.com|quora|reddit|t.co|twitch|viadeo|xing|youtube).*)|(yt|fb|li))$')>0
-       or regexp_count(lower(pv.mkt_medium),'^(.*)(social|facebook|linkedin|twitter|instagram|tweet)(.*)$')>0 then 'social'
+       or rlike(lower(pv.mkt_source),'^((.*(facebook|linkedin|instagram|insta|slideshare|social|tweet|twitter|youtube|lnkd|pinterest|googleplus|instagram|plus.google.com|quora|reddit|t.co|twitch|viadeo|xing|youtube).*)|(yt|fb|li))$')
+       or rlike(lower(pv.mkt_medium),'^(.*)(social|facebook|linkedin|twitter|instagram|tweet)(.*)$') then 'social'
       when pv.refr_medium = 'email'
        or pv.mkt_medium ilike '_mail' then 'email'
       when pv.mkt_medium ilike 'affiliate' then 'affiliate'
-      when pv.refr_medium = 'unknown' or lower(pv.mkt_medium) ilike 'referral' or lower(pv.mkt_medium) ilike 'referal' then 'referral'
+      when pv.refr_medium = 'unknown' or pv.mkt_medium ilike 'referral' or pv.mkt_medium ilike 'referal' then 'referral'
       when pv.refr_medium = 'internal' then 'internal'
       else 'others'
     end as channel,
@@ -80,10 +75,12 @@ with link_clicks as (
 select
   eng.page_view_id,
   eng.start_tstamp,
+  DATE(eng.start_tstamp) as start_tstamp_date,
   lc.link_clicks,
   lc.first_link_target,
   eng.is_bounced_page_view,
-  eng.engagement_score
+  eng.engagement_score,
+  eng.channel
 
 from engagement eng
 left join link_clicks lc

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/default/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/default/snowplow_web_pv_channel_engagement.sql
@@ -1,0 +1,91 @@
+--Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+
+{{ 
+  config(
+    materialized='snowplow_incremental',
+    unique_key='page_view_id',
+    upsert_date_key='start_tstamp',
+    sort='start_tstamp',
+    dist='page_view_id'
+  ) 
+}}
+
+with link_clicks as (
+  select
+    ev.page_view_id,
+
+    count(ev.event_id)
+      over(partition by ev.page_view_id
+      order by ev.derived_tstamp desc
+      rows between unbounded preceding and unbounded following)
+      as link_clicks,
+
+    first_value(lc.target_url)
+      over(partition by ev.page_view_id
+      order by ev.derived_tstamp desc
+      rows between unbounded preceding and unbounded following)
+      as first_link_target
+
+  from {{ source('atomic','com_snowplowanalytics_snowplow_link_click_1') }} lc
+
+  inner join {{ ref('snowplow_web_base_events_this_run' ) }} ev -- Select events from base_events_this_run rather than raw events table
+  on lc.root_id = ev.event_id and lc.root_tstamp = ev.collector_tstamp
+
+  where
+    lc.root_tstamp >= (select lower_limit from {{ ref('snowplow_web_base_new_event_limits') }}) -- limit link clicks table scan using the base_new_event_limits table
+    and lc.root_tstamp <= (select upper_limit from {{ ref('snowplow_web_base_new_event_limits') }})
+    and {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+)
+
+, engagement as (
+  select
+    pv.page_view_id,
+    pv.start_tstamp,
+    case
+      when pv.refr_medium = 'search'
+       and (lower(pv.mkt_medium) similar to '%(cpc|ppc|sem|paidsearch)%'
+         or lower(pv.mkt_source) similar to '%(cpc|ppc|sem|paidsearch)%') then 'paidsearch'
+      when lower(pv.mkt_medium) ilike '%paidsearch%'
+       or lower(pv.mkt_source) ilike '%paidsearch%' then 'paidsearch'
+      when lower(pv.mkt_source) similar to '%(adwords|google_paid|googleads)%'
+       or lower(pv.mkt_medium) similar to '%(adwords|google_paid|googleads)%' then 'paidsearch'
+      when pv.mkt_source ilike '%google%'
+       and pv.mkt_medium ilike '%ads%' then 'paidsearch'
+      when pv.refr_urlhost in ('www.googleadservices.com','googleads.g.doubleclick.net') then 'paidsearch'
+      when lower(pv.mkt_medium) similar to '%(cpv|cpa|cpp|content-text|advertising|ads)%' then 'advertising'
+      when lower(pv.mkt_medium) similar to '%(display|cpm|banner)%' then 'display'
+      when pv.refr_medium is null and pv.page_url not ilike '%utm_%' then 'direct'
+      when (lower(pv.refr_medium) = 'search' and pv.mkt_medium is null)
+       or (lower(pv.refr_medium) = 'search' and lower(pv.mkt_medium) = 'organic') then 'organicsearch'
+      when pv.refr_medium = 'social'
+       or regexp_count(lower(pv.mkt_source),'^((.*(facebook|linkedin|instagram|insta|slideshare|social|tweet|twitter|youtube|lnkd|pinterest|googleplus|instagram|plus.google.com|quora|reddit|t.co|twitch|viadeo|xing|youtube).*)|(yt|fb|li))$')>0
+       or regexp_count(lower(pv.mkt_medium),'^(.*)(social|facebook|linkedin|twitter|instagram|tweet)(.*)$')>0 then 'social'
+      when pv.refr_medium = 'email'
+       or pv.mkt_medium ilike '_mail' then 'email'
+      when pv.mkt_medium ilike 'affiliate' then 'affiliate'
+      when pv.refr_medium = 'unknown' or lower(pv.mkt_medium) ilike 'referral' or lower(pv.mkt_medium) ilike 'referal' then 'referral'
+      when pv.refr_medium = 'internal' then 'internal'
+      else 'others'
+    end as channel,
+    case
+      when pv.engaged_time_in_s = 0 then true
+      else false
+    end as is_bounced_page_view,
+    (pv.vertical_percentage_scrolled / 100) * 0.3 + (pv.engaged_time_in_s / 600) * 0.7 as engagement_score
+
+  from {{ ref('snowplow_web_page_views_this_run' ) }} pv --select from page_views_this_run rather than derived page_views table
+  where {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+)
+
+select
+  eng.page_view_id,
+  eng.start_tstamp,
+  lc.link_clicks,
+  lc.first_link_target,
+  eng.is_bounced_page_view,
+  eng.engagement_score,
+  eng.channel
+
+from engagement eng
+left join link_clicks lc
+on eng.page_view_id = lc.page_view_id

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/snowflake/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/snowflake/snowplow_web_pv_channel_engagement.sql
@@ -1,0 +1,87 @@
+--Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+
+{{ 
+  config(
+    materialized='snowplow_incremental',
+    unique_key='page_view_id',
+    upsert_date_key='start_tstamp',
+    cluster_by=snowplow_web.web_cluster_by_fields_page_views(),
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
+  ) 
+}}
+
+with link_clicks as (
+  select distinct
+    ev.page_view_id,
+
+    count(ev.event_id)
+      over(partition by ev.page_view_id
+      order by ev.derived_tstamp desc
+      rows between unbounded preceding and unbounded following)
+      as link_clicks,
+
+    first_value(ev.unstruct_event_com_snowplowanalytics_snowplow_link_click_1:targetUrl::varchar)
+      over(partition by ev.page_view_id
+      order by ev.derived_tstamp desc
+      rows between unbounded preceding and unbounded following)
+      as first_link_target
+
+  from {{ ref('snowplow_web_base_events_this_run' ) }} ev -- Select events from base_events_this_run rather than raw events table
+
+  where
+    {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+    and ev.unstruct_event_com_snowplowanalytics_snowplow_link_click_1 is not null -- only include link click events
+)
+
+, engagement as (
+  select
+    pv.page_view_id,
+    pv.start_tstamp,
+    case
+      when pv.refr_medium = 'search'
+       and (rlike(lower(pv.mkt_medium), '(cpc|ppc|sem|paidsearch)')
+         or rlike(lower(pv.mkt_source), '(cpc|ppc|sem|paidsearch)')) then 'paidsearch'
+      when pv.mkt_medium ilike '%paidsearch%'
+       or pv.mkt_source ilike '%paidsearch%' then 'paidsearch'
+      when rlike(lower(pv.mkt_source), '(adwords|google_paid|googleads)')
+       or rlike(lower(pv.mkt_medium), '(adwords|google_paid|googleads)') then 'paidsearch'
+      when pv.mkt_source ilike '%google%'
+       and pv.mkt_medium ilike '%ads%' then 'paidsearch'
+      when pv.refr_urlhost in ('www.googleadservices.com','googleads.g.doubleclick.net') then 'paidsearch'
+      when rlike(lower(pv.mkt_medium), '(cpv|cpa|cpp|content-text|advertising|ads)') then 'advertising'
+      when rlike(lower(pv.mkt_medium), '(display|cpm|banner)') then 'display'
+      when pv.refr_medium is null and pv.page_url not ilike '%utm_%' then 'direct'
+      when (lower(pv.refr_medium) = 'search' and pv.mkt_medium is null)
+       or (lower(pv.refr_medium) = 'search' and lower(pv.mkt_medium) = 'organic') then 'organicsearch'
+      when pv.refr_medium = 'social'
+       or regexp_count(lower(pv.mkt_source),'^((.*(facebook|linkedin|instagram|insta|slideshare|social|tweet|twitter|youtube|lnkd|pinterest|googleplus|instagram|plus.google.com|quora|reddit|t.co|twitch|viadeo|xing|youtube).*)|(yt|fb|li))$')>0
+       or regexp_count(lower(pv.mkt_medium),'^(.*)(social|facebook|linkedin|twitter|instagram|tweet)(.*)$')>0 then 'social'
+      when pv.refr_medium = 'email'
+       or lower(pv.mkt_medium) = '_mail' then 'email'
+      when lower(pv.mkt_medium) = 'affiliate' then 'affiliate'
+      when pv.refr_medium = 'unknown' or lower(pv.mkt_medium) = 'referral' or lower(pv.mkt_medium) = 'referal' then 'referral'
+      when pv.refr_medium = 'internal' then 'internal'
+      else 'others'
+    end as channel,
+    case
+      when pv.engaged_time_in_s = 0 then true
+      else false
+    end as is_bounced_page_view,
+    (pv.vertical_percentage_scrolled / 100) * 0.3 + (pv.engaged_time_in_s / 600) * 0.7 as engagement_score
+
+  from {{ ref('snowplow_web_page_views_this_run' ) }} pv --select from page_views_this_run rather than derived page_views table
+  where {{ snowplow_utils.is_run_with_new_events('snowplow_web') }} --returns false if run doesn't contain new events.
+)
+
+select
+  eng.page_view_id,
+  eng.start_tstamp,
+  lc.link_clicks,
+  lc.first_link_target,
+  eng.is_bounced_page_view,
+  eng.engagement_score,
+  eng.channel
+
+from engagement eng
+left join link_clicks lc
+on eng.page_view_id = lc.page_view_id

--- a/custom_example/models/snowplow_web_custom_modules/page_views/snowplow_web_page_views_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/snowplow_web_page_views_custom.sql
@@ -1,7 +1,8 @@
 -- materialized as a view since we are just joining two production tables.
 {{ 
   config(
-    materialized='view'
+    materialized='view',
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
   ) 
 }}
 
@@ -11,7 +12,8 @@ select
   ce.link_clicks,
   ce.first_link_target,
   ce.is_bounced_page_view,
-  ce.engagement_score
+  ce.engagement_score,
+  ce.channel
 
 from {{ ref('snowplow_web_page_views') }} pv -- Join together the two incremental production tables
 left join {{ ref('snowplow_web_pv_channel_engagement')}} ce

--- a/custom_example/models/snowplow_web_custom_modules/sessions/sessions_conversion/sessions_conversion.yml
+++ b/custom_example/models/snowplow_web_custom_modules/sessions/sessions_conversion/sessions_conversion.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: snowplow_web_sessions_conversion_this_run
-    description: Table the calculates intent to convert and conversion
+    description: Table that calculates intent to convert and conversion
     columns:
       - name: domain_sessionid
         tests:

--- a/custom_example/models/snowplow_web_custom_modules/sessions/sessions_conversion/snowplow_web_sessions_conversion_this_run.sql
+++ b/custom_example/models/snowplow_web_custom_modules/sessions/sessions_conversion/snowplow_web_sessions_conversion_this_run.sql
@@ -2,7 +2,8 @@
 {{ 
   config(
     sort='domain_sessionid',
-    dist='domain_sessionid'
+    dist='domain_sessionid',
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
   ) 
 }}
 

--- a/custom_example/models/snowplow_web_custom_modules/sessions/snowplow_web_sessions_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/sessions/snowplow_web_sessions_custom.sql
@@ -4,13 +4,22 @@
     unique_key='domain_sessionid',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
-    dist='domain_sessionid'
+    dist='domain_sessionid',
+    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+      "field": "start_tstamp",
+      "data_type": "timestamp"
+    }, databricks_partition_by='start_tstamp_date'),
+    cluster_by=snowplow_web.web_cluster_by_fields_sessions(),
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
   ) 
 }}
 
 
 select 
   s.*,
+  {% if target.type in ['databricks', 'spark'] -%}
+  , DATE(start_tstamp) as start_tstamp_date
+  {%- endif %}
   c.is_session_w_intent,
   c.is_session_w_conversion
 

--- a/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
@@ -4,15 +4,23 @@
     unique_key='user_primary_key',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
-    dist='user_primary_key'
+    dist='user_primary_key',
+    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+      "field": "start_tstamp",
+      "data_type": "timestamp"
+    }, databricks_partition_by='start_tstamp_date'),
+    cluster_by=snowplow_web.web_cluster_by_fields_users(),
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
   ) 
 }}
 
 
-select 
-  CONCAT(u.domain_userid, "-"  s.user_ipaddress) as user_primary_key,
-  u.*,
-
+select distinct
+  {{ dbt_utils.concat(["u.domain_userid", "'-'", "s.user_ipaddress"]) }} as user_primary_key,
+  u.*
+  {% if target.type in ['databricks', 'spark'] -%}
+  , DATE(start_tstamp) as start_tstamp_date
+  {%- endif %}
 
 from {{ ref('snowplow_web_users_this_run') }} u -- join sessions_this_run to sessions_conversion_this_run to produce complete sessions table
 left join {{ ref('snowplow_web_sessions')}} s on u.domain_userid = s.domain_userid

--- a/docs/markdown/snowplow_web_overview.md
+++ b/docs/markdown/snowplow_web_overview.md
@@ -256,10 +256,10 @@ dbt run --select +my_custom_module # Will execute only your custom module + any 
 
 ### Tearing down a subset of models
 
-As the code base for your custom modules evolves, you will likely need to replay events through a given module. In order to do so, the models within your custom module need to be removed from the `snowplow_web_incremental_manifest` table. See the 'Complete refresh' section for an explanation as to why. This removal can be achieved by passing the model's name to the `models_to_remove'` var at run time. If you want to replay events through a series of dependent models, you only need to pass the name of the endmost model within the run:
+As the code base for your custom modules evolves, you will likely need to replay events through a given module. In order to do so, you first need to manually drop the models within your custom module from your database. Then these models need to be removed from the `snowplow_web_incremental_manifest` table. See the 'Complete refresh' section for an explanation as to why. This removal can be achieved by passing the model's name to the `models_to_remove` var at run time. If you want to replay events through a series of dependent models, you only need to pass the name of the endmost model within the run:
 
 ```bash
-dbt run --select +snowplow_web_custom_incremental_model --full-refresh --vars 'models_to_remove: snowplow_web_custom_incremental_model'
+dbt run --select +snowplow_web_custom_incremental_model --vars '{snowplow__start_date: your_backfill_start_date, models_to_remove: snowplow_web_custom_incremental_model}'
 ```
 
 By removing the `snowplow_web_custom_incremental_model` model from the manifest the web packages will be in state 2 and will replay all events.

--- a/models/base/scratch/bigquery/snowplow_web_base_events_this_run.sql
+++ b/models/base/scratch/bigquery/snowplow_web_base_events_this_run.sql
@@ -28,7 +28,7 @@ from (
   and a.collector_tstamp >= {{ lower_limit }}
   and a.collector_tstamp <= {{ upper_limit }}
   {% if var('snowplow__derived_tstamp_partitioned', true) and target.type == 'bigquery' | as_bool() %}
-    and a.derived_tstamp >= {{ lower_limit }}
+    and a.derived_tstamp >= {{ snowplow_utils.timestamp_add('hour', -1, lower_limit) }}
     and a.derived_tstamp <= {{ upper_limit }}
   {% endif %}
   and {{ snowplow_utils.app_id_filter(var("snowplow__app_id",[])) }}


### PR DESCRIPTION
## Description & motivation

- Added custom examples for BigQuery, Snowflake and Databricks so that users can use these examples immediately regardless of what database they are using. #87 
-  Added a 1 hour buffer for the time filter for the `snowplow_web_base_events_this_run` model for BigQuery because `derived_tstamp` is sometimes earlier than the `collector_tstamp`.  #98 
- Fixed documentation for custom model teardown where previous instructions didn't work in Redshift. Added an alternative solution that works with all databases. #100 

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)