### PR TITLE
Drop support for dbt versions below 1.3 (Close #123)

### DIFF
--- a/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
@@ -1,4 +1,4 @@
-{{ 
+{{
   config(
     materialized='snowplow_incremental',
     unique_key='user_primary_key',
@@ -11,12 +11,12 @@
     }, databricks_partition_by='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_users(),
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
-  ) 
+  )
 }}
 
 
 select distinct
-  {{ dbt_utils.concat(["u.domain_userid", "'-'", "s.user_ipaddress"]) }} as user_primary_key,
+  {{ dbt.concat(["u.domain_userid", "'-'", "s.user_ipaddress"]) }} as user_primary_key,
   u.*
   {% if target.type in ['databricks', 'spark'] -%}
   , DATE(start_tstamp) as start_tstamp_date

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'snowplow_web'
 version: '0.11.0'
 config-version: 2
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.3.0", "<2.0.0"]
 
 profile: 'default'
 

--- a/models/base/manifest/snowplow_web_incremental_manifest.sql
+++ b/models/base/manifest/snowplow_web_incremental_manifest.sql
@@ -16,7 +16,7 @@
 with prep as (
   select
     cast(null as {{ snowplow_utils.type_string(4096) }}) model,
-    cast('1970-01-01' as {{ dbt_utils.type_timestamp() }}) as last_success
+    cast('1970-01-01' as {{ type_timestamp() }}) as last_success
 )
 
 select *

--- a/models/optional_modules/consent/snowplow_web_consent_cmp_stats.sql
+++ b/models/optional_modules/consent/snowplow_web_consent_cmp_stats.sql
@@ -78,7 +78,7 @@ select
   e.cmp_tstamp,
   f.first_consent_event_tstamp,
   f.event_type as first_consent_event_type,
-  {{ dbt_utils.datediff('e.cmp_tstamp', 'f.first_consent_event_tstamp', 'second') }} as cmp_interaction_time
+  {{ datediff('e.cmp_tstamp', 'f.first_consent_event_tstamp', 'second') }} as cmp_interaction_time
 
 from cmp_events e
 

--- a/models/optional_modules/consent/snowplow_web_consent_totals.sql
+++ b/models/optional_modules/consent/snowplow_web_consent_totals.sql
@@ -18,9 +18,9 @@ with totals as (
     count(case when last_consent_event_type = 'expired'  then 1 end) as expired,
     count(case when last_consent_event_type = 'withdrawn'  then 1 end) as withdrawn,
     count(case when last_consent_event_type = 'implicit_consent'  then 1 end) as implicit_consent,
-    count(case when {{ dbt_utils.dateadd('year', '1', 'last_consent_event_tstamp') }} <= {{ dbt_utils.dateadd('month', '6', 'current_date') }}
+    count(case when {{ dateadd('year', '1', 'last_consent_event_tstamp') }} <= {{ dateadd('month', '6', 'current_date') }}
           and last_consent_event_type <> 'expired'
-          and {{ dbt_utils.dateadd('year', '1', 'last_consent_event_tstamp') }} > current_date then 1 end) as expires_in_six_months
+          and {{ dateadd('year', '1', 'last_consent_event_tstamp') }} > current_date then 1 end) as expires_in_six_months
 
   from {{ ref('snowplow_web_consent_users') }}
 
@@ -49,4 +49,3 @@ left join totals t
 on t.last_consent_version = v.consent_version
 
 order by v.version_start_tstamp desc
-

--- a/models/page_views/scratch/bigquery/snowplow_web_page_views_this_run.sql
+++ b/models/page_views/scratch/bigquery/snowplow_web_page_views_this_run.sql
@@ -146,7 +146,7 @@ select
   ev.derived_tstamp,
   ev.start_tstamp,
   coalesce(t.end_tstamp, ev.derived_tstamp) as end_tstamp, -- only page views with pings will have a row in table t
-  {{ dbt_utils.current_timestamp_in_utc() }} as model_tstamp,
+  {{ snowplow_utils.current_timestamp_in_utc() }} as model_tstamp,
 
   coalesce(t.engaged_time_in_s, 0) as engaged_time_in_s, -- where there are no pings, engaged time is 0.
   timestamp_diff(coalesce(t.end_tstamp, ev.derived_tstamp), ev.derived_tstamp, second)  as absolute_time_in_s,

--- a/models/page_views/scratch/databricks/snowplow_web_page_views_this_run.sql
+++ b/models/page_views/scratch/databricks/snowplow_web_page_views_this_run.sql
@@ -88,9 +88,9 @@ select
 
   {% else %}
 
-  cast(null as {{ dbt_utils.type_string() }}) as category,
-  cast(null as {{ dbt_utils.type_string() }}) as primary_impact,
-  cast(null as {{ dbt_utils.type_string() }}) as reason,
+  cast(null as {{ type_string() }}) as category,
+  cast(null as {{ type_string() }}) as primary_impact,
+  cast(null as {{ type_string() }}) as reason,
   cast(null as boolean) as spider_or_robot,
 
   {% endif %}
@@ -113,18 +113,18 @@ select
 
   {% else %}
 
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_family,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_major,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_minor,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_patch,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_version,
-  cast(null as {{ dbt_utils.type_string() }}) as os_family,
-  cast(null as {{ dbt_utils.type_string() }}) as os_major,
-  cast(null as {{ dbt_utils.type_string() }}) as os_minor,
-  cast(null as {{ dbt_utils.type_string() }}) as os_patch,
-  cast(null as {{ dbt_utils.type_string() }}) as os_patch_minor,
-  cast(null as {{ dbt_utils.type_string() }}) as os_version,
-  cast(null as {{ dbt_utils.type_string() }}) as device_family,
+  cast(null as {{ type_string() }}) as useragent_family,
+  cast(null as {{ type_string() }}) as useragent_major,
+  cast(null as {{ type_string() }}) as useragent_minor,
+  cast(null as {{ type_string() }}) as useragent_patch,
+  cast(null as {{ type_string() }}) as useragent_version,
+  cast(null as {{ type_string() }}) as os_family,
+  cast(null as {{ type_string() }}) as os_major,
+  cast(null as {{ type_string() }}) as os_minor,
+  cast(null as {{ type_string() }}) as os_patch,
+  cast(null as {{ type_string() }}) as os_patch_minor,
+  cast(null as {{ type_string() }}) as os_version,
+  cast(null as {{ type_string() }}) as device_family,
 
   {% endif %}
 
@@ -154,26 +154,26 @@ select
 
   {% else %}
 
-  cast(null as {{ dbt_utils.type_string() }}) as device_class,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_class,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_name,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_name_version,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_name_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_version,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as device_brand,
-  cast(null as {{ dbt_utils.type_string() }}) as device_name,
-  cast(null as {{ dbt_utils.type_string() }}) as device_version,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_class,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_name,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_name_version,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_name_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_version,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_class,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_name,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_name_version,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_version
+  cast(null as {{ type_string() }}) as device_class,
+  cast(null as {{ type_string() }}) as agent_class,
+  cast(null as {{ type_string() }}) as agent_name,
+  cast(null as {{ type_string() }}) as agent_name_version,
+  cast(null as {{ type_string() }}) as agent_name_version_major,
+  cast(null as {{ type_string() }}) as agent_version,
+  cast(null as {{ type_string() }}) as agent_version_major,
+  cast(null as {{ type_string() }}) as device_brand,
+  cast(null as {{ type_string() }}) as device_name,
+  cast(null as {{ type_string() }}) as device_version,
+  cast(null as {{ type_string() }}) as layout_engine_class,
+  cast(null as {{ type_string() }}) as layout_engine_name,
+  cast(null as {{ type_string() }}) as layout_engine_name_version,
+  cast(null as {{ type_string() }}) as layout_engine_name_version_major,
+  cast(null as {{ type_string() }}) as layout_engine_version,
+  cast(null as {{ type_string() }}) as layout_engine_version_major,
+  cast(null as {{ type_string() }}) as operating_system_class,
+  cast(null as {{ type_string() }}) as operating_system_name,
+  cast(null as {{ type_string() }}) as operating_system_name_version,
+  cast(null as {{ type_string() }}) as operating_system_version
 
   {% endif %}
 
@@ -213,7 +213,7 @@ select
     p.derived_tstamp,
     p.start_tstamp,
     coalesce(t.end_tstamp, p.derived_tstamp) as end_tstamp, -- only page views with pings will have a row in table t
-    {{ dbt_utils.current_timestamp_in_utc() }} as model_tstamp,
+    {{ snowplow_utils.current_timestamp_in_utc() }} as model_tstamp,
 
     coalesce(t.engaged_time_in_s, 0) as engaged_time_in_s, -- where there are no pings, engaged time is 0.
     datediff(second, p.derived_tstamp, coalesce(t.end_tstamp, p.derived_tstamp))  as absolute_time_in_s,

--- a/models/page_views/scratch/default/snowplow_web_page_views_this_run.sql
+++ b/models/page_views/scratch/default/snowplow_web_page_views_this_run.sql
@@ -29,10 +29,10 @@ select
   ev.derived_tstamp,
   ev.start_tstamp,
   coalesce(t.end_tstamp, ev.derived_tstamp) as end_tstamp, -- only page views with pings will have a row in table t
-  {{ dbt_utils.current_timestamp_in_utc() }} as model_tstamp,
+  {{ snowplow_utils.current_timestamp_in_utc() }} as model_tstamp,
 
   coalesce(t.engaged_time_in_s, 0) as engaged_time_in_s, -- where there are no pings, engaged time is 0.
-  {{ dbt_utils.datediff('ev.derived_tstamp', 'coalesce(t.end_tstamp, ev.derived_tstamp)', 'second') }} as absolute_time_in_s,
+  {{ datediff('ev.derived_tstamp', 'coalesce(t.end_tstamp, ev.derived_tstamp)', 'second') }} as absolute_time_in_s,
 
   sd.hmax as horizontal_pixels_scrolled,
   sd.vmax as vertical_pixels_scrolled,

--- a/models/page_views/scratch/snowflake/snowplow_web_page_views_this_run.sql
+++ b/models/page_views/scratch/snowflake/snowplow_web_page_views_this_run.sql
@@ -88,9 +88,9 @@ select
 
   {% else %}
 
-  cast(null as {{ dbt_utils.type_string() }}) as category,
-  cast(null as {{ dbt_utils.type_string() }}) as primary_impact,
-  cast(null as {{ dbt_utils.type_string() }}) as reason,
+  cast(null as {{ type_string() }}) as category,
+  cast(null as {{ type_string() }}) as primary_impact,
+  cast(null as {{ type_string() }}) as reason,
   cast(null as boolean) as spider_or_robot,
 
   {% endif %}
@@ -113,18 +113,18 @@ select
 
   {% else %}
 
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_family,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_major,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_minor,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_patch,
-  cast(null as {{ dbt_utils.type_string() }}) as useragent_version,
-  cast(null as {{ dbt_utils.type_string() }}) as os_family,
-  cast(null as {{ dbt_utils.type_string() }}) as os_major,
-  cast(null as {{ dbt_utils.type_string() }}) as os_minor,
-  cast(null as {{ dbt_utils.type_string() }}) as os_patch,
-  cast(null as {{ dbt_utils.type_string() }}) as os_patch_minor,
-  cast(null as {{ dbt_utils.type_string() }}) as os_version,
-  cast(null as {{ dbt_utils.type_string() }}) as device_family,
+  cast(null as {{ type_string() }}) as useragent_family,
+  cast(null as {{ type_string() }}) as useragent_major,
+  cast(null as {{ type_string() }}) as useragent_minor,
+  cast(null as {{ type_string() }}) as useragent_patch,
+  cast(null as {{ type_string() }}) as useragent_version,
+  cast(null as {{ type_string() }}) as os_family,
+  cast(null as {{ type_string() }}) as os_major,
+  cast(null as {{ type_string() }}) as os_minor,
+  cast(null as {{ type_string() }}) as os_patch,
+  cast(null as {{ type_string() }}) as os_patch_minor,
+  cast(null as {{ type_string() }}) as os_version,
+  cast(null as {{ type_string() }}) as device_family,
 
   {% endif %}
 
@@ -154,26 +154,26 @@ select
 
   {% else %}
 
-  cast(null as {{ dbt_utils.type_string() }}) as device_class,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_class,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_name,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_name_version,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_name_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_version,
-  cast(null as {{ dbt_utils.type_string() }}) as agent_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as device_brand,
-  cast(null as {{ dbt_utils.type_string() }}) as device_name,
-  cast(null as {{ dbt_utils.type_string() }}) as device_version,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_class,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_name,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_name_version,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_name_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_version,
-  cast(null as {{ dbt_utils.type_string() }}) as layout_engine_version_major,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_class,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_name,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_name_version,
-  cast(null as {{ dbt_utils.type_string() }}) as operating_system_version
+  cast(null as {{ type_string() }}) as device_class,
+  cast(null as {{ type_string() }}) as agent_class,
+  cast(null as {{ type_string() }}) as agent_name,
+  cast(null as {{ type_string() }}) as agent_name_version,
+  cast(null as {{ type_string() }}) as agent_name_version_major,
+  cast(null as {{ type_string() }}) as agent_version,
+  cast(null as {{ type_string() }}) as agent_version_major,
+  cast(null as {{ type_string() }}) as device_brand,
+  cast(null as {{ type_string() }}) as device_name,
+  cast(null as {{ type_string() }}) as device_version,
+  cast(null as {{ type_string() }}) as layout_engine_class,
+  cast(null as {{ type_string() }}) as layout_engine_name,
+  cast(null as {{ type_string() }}) as layout_engine_name_version,
+  cast(null as {{ type_string() }}) as layout_engine_name_version_major,
+  cast(null as {{ type_string() }}) as layout_engine_version,
+  cast(null as {{ type_string() }}) as layout_engine_version_major,
+  cast(null as {{ type_string() }}) as operating_system_class,
+  cast(null as {{ type_string() }}) as operating_system_name,
+  cast(null as {{ type_string() }}) as operating_system_name_version,
+  cast(null as {{ type_string() }}) as operating_system_version
 
   {% endif %}
 
@@ -213,7 +213,7 @@ select
     p.derived_tstamp,
     p.start_tstamp,
     coalesce(t.end_tstamp, p.derived_tstamp) as end_tstamp, -- only page views with pings will have a row in table t
-    {{ dbt_utils.current_timestamp_in_utc() }} as model_tstamp,
+    {{ snowplow_utils.current_timestamp_in_utc() }} as model_tstamp,
 
     coalesce(t.engaged_time_in_s, 0) as engaged_time_in_s, -- where there are no pings, engaged time is 0.
     timediff(second, p.derived_tstamp, coalesce(t.end_tstamp, p.derived_tstamp))  as absolute_time_in_s,

--- a/models/page_views/scratch/snowplow_web_pv_scroll_depth.sql
+++ b/models/page_views/scratch/snowplow_web_pv_scroll_depth.sql
@@ -48,9 +48,9 @@ select
   vmin,
   vmax,
 
-  cast(round(100*(greatest(hmin, 0)/cast(doc_width as {{ dbt_utils.type_float() }}))) as {{ dbt_utils.type_float() }}) as relative_hmin, -- brackets matter: because hmin is of type int, we need to divide before we multiply by 100 or we risk an overflow
-  cast(round(100*(least(hmax + br_viewwidth, doc_width)/cast(doc_width as {{ dbt_utils.type_float() }}))) as {{ dbt_utils.type_float() }}) as relative_hmax,
-  cast(round(100*(greatest(vmin, 0)/cast(doc_height as {{ dbt_utils.type_float() }}))) as {{ dbt_utils.type_float() }}) as relative_vmin,
-  cast(round(100*(least(vmax + br_viewheight, doc_height)/cast(doc_height as {{ dbt_utils.type_float() }}))) as {{ dbt_utils.type_float() }}) as relative_vmax -- not zero when a user hasn't scrolled because it includes the non-zero viewheight
+  cast(round(100*(greatest(hmin, 0)/cast(doc_width as {{ type_float() }}))) as {{ type_float() }}) as relative_hmin, -- brackets matter: because hmin is of type int, we need to divide before we multiply by 100 or we risk an overflow
+  cast(round(100*(least(hmax + br_viewwidth, doc_width)/cast(doc_width as {{ type_float() }}))) as {{ type_float() }}) as relative_hmax,
+  cast(round(100*(greatest(vmin, 0)/cast(doc_height as {{ type_float() }}))) as {{ type_float() }}) as relative_vmin,
+  cast(round(100*(least(vmax + br_viewheight, doc_height)/cast(doc_height as {{ type_float() }}))) as {{ type_float() }}) as relative_vmax -- not zero when a user hasn't scrolled because it includes the non-zero viewheight
 
 from prep

--- a/models/sessions/scratch/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/snowplow_web_sessions_this_run.sql
@@ -16,7 +16,7 @@ select
 
   b.start_tstamp,
   b.end_tstamp,
-  {{ dbt_utils.current_timestamp_in_utc() }} as model_tstamp,
+  {{ snowplow_utils.current_timestamp_in_utc() }} as model_tstamp,
 
   -- user fields
   a.user_id,

--- a/models/users/scratch/snowplow_web_users_this_run.sql
+++ b/models/users/scratch/snowplow_web_users_this_run.sql
@@ -13,7 +13,7 @@ select
 
   b.start_tstamp,
   b.end_tstamp,
-  {{ dbt_utils.current_timestamp_in_utc() }} as model_tstamp,
+  {{ snowplow_utils.current_timestamp_in_utc() }} as model_tstamp,
 
   -- engagement fields
   b.page_views,

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: [">=0.12.3", "<0.13.0"]
+    version: [">=0.13.0", "<0.14.0"]


### PR DESCRIPTION
## Description & motivation
Update `dbt-snowplow-web` to support dbt v1.3+

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
