### PR TITLE
Update publish gh pages action with path and bq catch

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -109,6 +109,8 @@ jobs:
         cp target/manifest.json ../docs/manifest.json
         cp target/run_results.json ../docs/run_results.json
         dbt run-operation post_ci_cleanup --target ${{ matrix.warehouse }}
+    - name: Delete BigQuery creds to json file
+      run: rm -f ./dbt-service-account.json
     - name: Commit & Push changes
       uses: EndBug/add-and-commit@v9
       with:
@@ -117,6 +119,7 @@ jobs:
         # - user_info -> Your Display Name <your-actual@email.com>
         # - github_actions -> github-actions <email associated with the github logo>
         # Default: github_actor
+        add: ./docs/catalog.json ./docs/manifest.json ./docs/run_results.json
         default_author: github_actions
         message: 'Update dbt docs'
         new_branch: gh_pages

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 dbt_packages/
 logs/
+.DS_Store
+dbt-service-account.json


### PR DESCRIPTION
## Description & motivation
Update the actiont that generates the docs for gh pages, ensuring the service account file is both deleted (if it exists) and not added to the commit if it somehow doesn't get deleted.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [NA] I have added tests & descriptions to my models (and macros if applicable)
- [NA] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
