### PR TITLE
Move ref in enabled check (Close #155)

### DIFF
--- a/macros/stitch_user_identifiers.sql
+++ b/macros/stitch_user_identifiers.sql
@@ -1,20 +1,20 @@
-{% macro stitch_user_identifiers(enabled, relation=this, user_mapping_relation=ref('snowplow_web_user_mapping')) %}
+{% macro stitch_user_identifiers(enabled, relation=this, user_mapping_relation='snowplow_web_user_mapping') %}
 
   {% if enabled and target.type not in ['databricks', 'spark'] | as_bool() %}
 
     -- Update sessions table with mapping
     update {{ relation }} as s
     set stitched_user_id = um.user_id
-    from {{ user_mapping_relation }} as um
+    from {{ ref(user_mapping_relation) }} as um
     where s.domain_userid = um.domain_userid;
 
   {% elif enabled and target.type in ['databricks', 'spark']  | as_bool() %}
 
     -- Update sessions table with mapping
     merge into {{ relation }} as s
-    using {{ user_mapping_relation }} as um
+    using {{ ref(user_mapping_relation) }} as um
     on s.domain_userid = um.domain_userid
-    when matched then 
+    when matched then
       update set s.stitched_user_id = um.user_id;
 
   {% endif %}


### PR DESCRIPTION
## Description & motivation
Move reference inside the enabled block check to remove depdendency when user stitching is not enabled.

## Checklist
- [x] I have verified that these changes work locally
- [NA] I have updated the README.md (if applicable)
- [NA] I have added tests & descriptions to my models (and macros if applicable)
- [NA] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
