### PR TITLE
change macro inheritence calls

### DIFF
--- a/docs/markdown/snowplow_web_macros_docs.md
+++ b/docs/markdown/snowplow_web_macros_docs.md
@@ -57,3 +57,73 @@ and not rlike(useragent, '.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit
 ```
 {% endraw %}
 {% enddocs %}
+
+{% docs macro_stitch_user_identifiers %}
+{% raw %}		
+This macro is used as a post-hook on the sessions table to stitch user identities using the user_mapping table provided.
+- 
+#### Returns
+
+The update/merge statement to update the `stitched_user_id` column, if enabled.
+{% endraw %}
+{% enddocs %}
+
+{% docs macro_get_iab_context_fields %}
+{% raw %}		
+This macro is used to extract the fields from the iab enrichment context for each warehouse.
+- 
+#### Returns
+
+The sql to extract the columns from the iab context, or these columns as nulls.
+{% endraw %}
+{% enddocs %}
+
+{% docs macro_get_ua_context_fields %}
+{% raw %}		
+This macro is used to extract the fields from the ua enrichment context for each warehouse.
+- 
+#### Returns
+
+The sql to extract the columns from the ua context, or these columns as nulls.
+{% endraw %}
+{% enddocs %}
+
+{% docs macro_get_yauaa_context_fields %}
+{% raw %}		
+This macro is used to extract the fields from the yauaa enrichment context for each warehouse.
+- 
+#### Returns
+
+The sql to extract the columns from the yauaa context, or these columns as nulls.
+{% endraw %}
+{% enddocs %}
+
+{% docs macro_web_cluster_by_X %}
+{% raw %}		
+This macro is used to return the appropriate `cluster_by` fields for the table, depending on the warehouse target.
+- 
+#### Returns
+
+The specific fields for each warehouse (see macro code for values).
+{% endraw %}
+{% enddocs %}
+
+{% docs macro_bq_context_fields %}
+{% raw %}		
+This macro is used to return the appropriate field and type mapping for use in `snowplow_utils.get_optional_fields`.
+- 
+#### Returns
+
+The specific fields and their type for the context (see macro code for values).
+{% endraw %}
+{% enddocs %}
+
+{% docs macro_allow_refresh %}
+{% raw %}		
+This macro is used to determine if a full-refresh is allowed (depending on the environment), using the `snowplow__allow_refresh` variable.
+- 
+#### Returns
+`snowplow__allow_refresh` if environment is not `dev`, `none` otherwise.
+
+{% endraw %}
+{% enddocs %}

--- a/macros/filter_bots.sql
+++ b/macros/filter_bots.sql
@@ -10,7 +10,7 @@
   and not regexp_contains({% if table_alias %}{{table_alias~'.'}}{% endif %}useragent, '(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt)')
 {% endmacro %}
 
-{% macro databricks__filter_bots(table_alias = none) %}
+{% macro spark__filter_bots(table_alias = none) %}
   and not rlike({% if table_alias %}{{table_alias~'.'}}{% endif %}useragent, '.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt).*')
 {% endmacro %}
 

--- a/macros/get_context_fields.sql
+++ b/macros/get_context_fields.sql
@@ -11,7 +11,7 @@
 {%- endmacro -%}
 
 {# iab fields #}
-{% macro default__get_iab_context_fields(table_prefix = none) %}
+{% macro postgres__get_iab_context_fields(table_prefix = none) %}
     {%- if var('snowplow__enable_iab', false) -%}
         {% if table_prefix %}table_prefix.{% endif %}category,
         {% if table_prefix %}table_prefix.{% endif %}primary_impact,
@@ -25,7 +25,13 @@
     {%- endif -%}
 {% endmacro %}
 
-{% macro databricks__get_iab_context_fields(table_prefix = none) %}
+{% macro bigquery__get_iab_context_fields(table_prefix = none) %}
+    {% if execute %}
+        {% do exceptions.raise_compiler_error('get_iab_context_fields is not defined for bigquery, please use snowplow_utils.get_optional_fields instead') %}
+    {% endif %}
+{% endmacro %}
+
+{% macro spark__get_iab_context_fields(table_prefix = none) %}
     {%- if var('snowplow__enable_iab', false) -%}
         {% if table_prefix %}table_prefix.{% endif %}contexts_com_iab_snowplow_spiders_and_robots_1[0].category::STRING as category,
         {% if table_prefix %}table_prefix.{% endif %}contexts_com_iab_snowplow_spiders_and_robots_1[0]:primaryImpact::STRING as primary_impact,
@@ -55,7 +61,7 @@
 {% endmacro %}
 
 {# ua fields #}
-{% macro default__get_ua_context_fields(table_prefix = none) %}
+{% macro postgres__get_ua_context_fields(table_prefix = none) %}
     {%- if var('snowplow__enable_ua', false) -%}
         {% if table_prefix %}table_prefix.{% endif %}useragent_family,
         {% if table_prefix %}table_prefix.{% endif %}useragent_major,
@@ -85,7 +91,13 @@
     {%- endif -%}
 {% endmacro %}
 
-{% macro databricks__get_ua_context_fields(table_prefix = none) %}
+{% macro bigquery__get_ua_context_fields(table_prefix = none) %}
+    {% if execute %}
+        {% do exceptions.raise_compiler_error('get_ua_context_fields is not defined for bigquery, please use snowplow_utils.get_optional_fields instead') %}
+    {% endif %}
+{% endmacro %}
+
+{% macro spark__get_ua_context_fields(table_prefix = none) %}
     {%- if var('snowplow__enable_ua', false) -%}
         {% if table_prefix %}table_prefix.{% endif %}contexts_com_snowplowanalytics_snowplow_ua_parser_context_1[0]:useragentFamily::STRING as useragent_family,
         {% if table_prefix %}table_prefix.{% endif %}contexts_com_snowplowanalytics_snowplow_ua_parser_context_1[0]:useragentMajor::STRING as useragent_major,
@@ -147,7 +159,7 @@
 {% endmacro %}
 
 {# yauaa fields #}
-{% macro default__get_yauaa_context_fields(table_prefix = none) %}
+{% macro postgres__get_yauaa_context_fields(table_prefix = none) %}
     {%- if var('snowplow__enable_yauaa', false) -%}
         {% if table_prefix %}table_prefix.{% endif %}device_class,
         {% if table_prefix %}table_prefix.{% endif %}agent_class,
@@ -193,7 +205,13 @@
     {%- endif -%}
 {% endmacro %}
 
-{% macro databricks__get_yauaa_context_fields(table_prefix = none) %}
+{% macro bigquery__get_yauaa_context_fields(table_prefix = none) %}
+    {% if execute %}
+        {% do exceptions.raise_compiler_error('get_yauaa_context_fields is not defined for bigquery, please use snowplow_utils.get_optional_fields instead') %}
+    {% endif %}
+{% endmacro %}
+
+{% macro spark__get_yauaa_context_fields(table_prefix = none) %}
     {%- if var('snowplow__enable_yauaa', false) -%}
         {% if table_prefix %}table_prefix.{% endif %}contexts_nl_basjes_yauaa_context_1[0]:deviceClass as device_class,
         {% if table_prefix %}table_prefix.{% endif %}contexts_nl_basjes_yauaa_context_1[0]:agentClass::STRING as agent_class,

--- a/macros/macros.yml
+++ b/macros/macros.yml
@@ -7,3 +7,51 @@ macros:
       - name: table_alias
         type: string
         description: (Optional) the table alias to identify the useragent column from. Default none
+  - name: stitch_user_identifiers
+    description: '{{ doc("macro_stitch_user_identifiers") }}'
+    arguments:
+      - name: enabled
+        type: boolean
+        description: If the user stitching should be done or not
+      - name: relation
+        type: string
+        description: (Optional) The model to update the `stitched_user_id` column in. Default `this`
+      - name: user_mapping_relation
+        type: string
+        description: (Optional) The model to use the `user_id` column from. Default `snowplow_web_user_mapping`
+  - name: get_iab_context_fields
+    description: '{{ doc("macro_get_iab_context_fields") }}'
+    arguments:
+      - name: table_prefix
+        type: string
+        description: (Optional) Table alias to prefix the column selection with. Default none
+  - name: get_ua_context_fields
+    description: '{{ doc("macro_get_ua_context_fields") }}'
+    arguments:
+      - name: table_prefix
+        type: string
+        description: (Optional) Table alias to prefix the column selection with. Default none
+  - name: get_yauaa_context_fields
+    description: '{{ doc("macro_get_yauaa_context_fields") }}'
+    arguments:
+      - name: table_prefix
+        type: string
+        description: (Optional) Table alias to prefix the column selection with. Default none
+  - name: web_cluster_by_fields_sessions_lifecycle
+    description: '{{ doc("macro_web_cluster_by_X") }}'
+  - name: web_cluster_by_fields_page_views
+    description: '{{ doc("macro_web_cluster_by_X") }}'
+  - name: web_cluster_by_fields_sessions
+    description: '{{ doc("macro_web_cluster_by_X") }}'
+  - name: web_cluster_by_fields_users
+    description: '{{ doc("macro_web_cluster_by_X") }}'
+  - name: web_cluster_by_fields_consent
+    description: '{{ doc("macro_web_cluster_by_X") }}'
+  - name: iab_fields
+    description: '{{ doc("macro_bq_context_fields") }}'
+  - name: ua_fields
+    description: '{{ doc("macro_bq_context_fields") }}'
+  - name: yauaa_fields
+    description: '{{ doc("macro_bq_context_fields") }}'
+  - name: allow_refresh
+    description: '{{ doc("macro_allow_refresh") }}'

--- a/macros/stitch_user_identifiers.sql
+++ b/macros/stitch_user_identifiers.sql
@@ -1,22 +1,24 @@
 {% macro stitch_user_identifiers(enabled, relation=this, user_mapping_relation='snowplow_web_user_mapping') %}
+    {{ return(adapter.dispatch('stitch_user_identifiers', 'snowplow_web')(enabled, relation, user_mapping_relation)) }}
+{%- endmacro -%}
 
-  {% if enabled and target.type not in ['databricks', 'spark'] | as_bool() %}
+{% macro default__stitch_user_identifiers(enabled, relation=this, user_mapping_relation='snowplow_web_user_mapping') %}
+    {% if enabled | as_bool() %}
+      -- Update sessions table with mapping
+      update {{ relation }} as s
+      set stitched_user_id = um.user_id
+      from {{ ref(user_mapping_relation) }} as um
+      where s.domain_userid = um.domain_userid;
+    {% endif %}
+{%- endmacro -%}
 
-    -- Update sessions table with mapping
-    update {{ relation }} as s
-    set stitched_user_id = um.user_id
-    from {{ ref(user_mapping_relation) }} as um
-    where s.domain_userid = um.domain_userid;
-
-  {% elif enabled and target.type in ['databricks', 'spark']  | as_bool() %}
-
-    -- Update sessions table with mapping
-    merge into {{ relation }} as s
-    using {{ ref(user_mapping_relation) }} as um
-    on s.domain_userid = um.domain_userid
-    when matched then
+{% macro spark__stitch_user_identifiers(enabled, relation=this, user_mapping_relation='snowplow_web_user_mapping') %}
+    {% if enabled | as_bool() %}
+      -- Update sessions table with mapping
+      merge into {{ relation }} as s
+      using {{ ref(user_mapping_relation) }} as um
+      on s.domain_userid = um.domain_userid
+      when matched then
       update set s.stitched_user_id = um.user_id;
-
-  {% endif %}
-
-{% endmacro %}
+    {% endif %}
+{%- endmacro -%}


### PR DESCRIPTION
## Description & motivation
As discussed in other PR, pointing databricks macros to spark instead, and using the adaptor dispatch for the user stitching macro (not sure if there was a reason we didn't do this to begin with?).

Removed the default option for `get_optional_fields` as BQ has it's own method and we don't want it to accidently get called in a bigquery model - this will ensure it's an easier error to debug if it somehow happens.

Also, added in docs for all macros using the new approach. I re-use some of the content between similar macros to save duplication.

## Checklist
- [ ] I have verified that these changes work locally
- [NA] I have updated the README.md (if applicable)
- [NA] I have added tests & descriptions to my models (and macros if applicable)
- [NA] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required) - but I have updated our internal style guide
