### PR TITLE
Migrate to Predicate incremental materialization

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,9 +2,13 @@ name: 'snowplow_web'
 version: '0.13.2'
 config-version: 2
 
-require-dbt-version: [">=1.3.0", "<2.0.0"]
+require-dbt-version: [">=1.4.0", "<2.0.0"]
 
 profile: 'default'
+
+dispatch:
+  - macro_namespace: dbt
+    search_order: ['snowplow_utils', 'dbt']
 
 model-paths: ["models"]
 test-paths: ["tests"]
@@ -52,7 +56,7 @@ vars:
     snowplow__max_session_days: 3
     snowplow__upsert_lookback_days: 30
     snowplow__query_tag: "snowplow_dbt"
-    snowplow__incremental_materialization: "snowplow_incremental"
+    snowplow__incremental_materialization: "incremental"
     snowplow__dev_target_name: 'dev'
     snowplow__allow_refresh: false
     # snowplow__limit_page_views_to_session: true

--- a/models/base/manifest/snowplow_web_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/snowplow_web_base_sessions_lifecycle_manifest.sql
@@ -16,7 +16,8 @@
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    }
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/page_views/snowplow_web_page_views.sql
+++ b/models/page_views/snowplow_web_page_views.sql
@@ -15,7 +15,8 @@
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    }
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/sessions/snowplow_web_sessions.sql
+++ b/models/sessions/snowplow_web_sessions.sql
@@ -18,7 +18,8 @@
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    }
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/models/users/snowplow_web_users.sql
+++ b/models/users/snowplow_web_users.sql
@@ -16,7 +16,8 @@
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    }
+    },
+    snowplow_optimize = true
   )
 }}
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,4 @@
 packages:
-  - package: snowplow/snowplow_utils
-    version: 0.14.0rc1
+  # - package: snowplow/snowplow_utils
+  - git: "https://github.com/snowplow/dbt-snowplow-utils.git" # git URL
+    revision: feature/predicate-incremental-materialization # tag or branch name

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: [">=0.13.1", "<0.14.0"]
+    version: 0.14.0rc1


### PR DESCRIPTION
## Description & motivation
See https://github.com/snowplow/dbt-snowplow-utils/pull/117 for details about the change in materialization.

### Problem you are trying to solve

The package currently uses the snowplow_incremental materialization which we are on the path to replacing due to it being hard to maintain. 

### How you solved it

This PR changes to the new snowplow optimised incremental materialization method, by dispatching to the`snowplow_utils` to generate the sql first, then passing this on to dbt. We make this swap in all core places the old materizliation was used, which excludes the custom model and the consent tracking for now (these will following in a later release candidate/final release).

Finally it adds the `snowplow__disable_upsert_lookback` variable into the variables list as it was missing and would be good to provide to users.

### Decision points
- Not updating the custom model/consent/integration test that still use the old materialization was done to focus on only changing the core workings of the package, to better test just these changes with our customers
- Currently the `snowplow__incremental_materialization` is still part of the package, it doens't need to be?

### Discussion

https://github.com/snowplow/dbt-snowplow-web/discussions/160

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (https://github.com/snowplow/documentation/pull/327)

