### PR TITLE
Add snowplow__enable_load_tstamp variable (Close #162)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -44,6 +44,7 @@ vars:
     snowplow__ua_bot_filter: true
     snowplow__derived_tstamp_partitioned: true
     snowplow__session_stitching: true
+    snowplow__enable_load_tstamp: true # set to false if you are using the postgres loader or earlier than 4.0.0 of the RDB loader
     # Variables - Advanced Config
     snowplow__lookback_window_hours: 6
     snowplow__session_lookback_days: 730

--- a/models/base/scratch/default/snowplow_web_base_events_this_run.sql
+++ b/models/base/scratch/default/snowplow_web_base_events_this_run.sql
@@ -143,7 +143,9 @@ with events_this_run AS (
     a.event_version,
     a.event_fingerprint,
     a.true_tstamp,
-    a.load_tstamp,
+    {% if var('snowplow__enable_load_tstamp', true) %}
+      a.load_tstamp,
+    {% endif %}
     dense_rank() over (partition by a.event_id order by a.collector_tstamp) as event_id_dedupe_index --dense_rank so rows with equal tstamps assigned same number
 
   from {{ var('snowplow__events') }} as a


### PR DESCRIPTION
## Description & motivation
Adds a variable to allow users to disable the selecting of the load_tstamp column in postgres/redshfit for people on postgres/older loaders.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Adding into the megadocs release in the next hour)
