### PR TITLE
Release/snowplow web/0.13.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+snowplow-web 0.13.1 (2023-02-24)
+---------------------------------------
+## Summary
+This is a patch release with the purpose to unblock those Redshift/Postgres users whose loaders do not send `load_tstamp` field to their events table: they use `Postgres loader` or `RDB Loader` below v4.0.0. Please note that they will not be able to use the Consent models but the general web model will still be supported.
+
+## Upgrading
+Apart from bumping the snowplow-web version in your `packages.yml` file, impacted users will need to set a newly introduced variable: `snowplow__enable_load_tstamp` to `false`.
+
+
 snowplow-web 0.13.0 (2023-02-22)
 ---------------------------------------
 ## Summary

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The snowplow-web v0.13.0 package currently supports BigQuery, Databricks, Redshi
 
 |                      Warehouse                       |    dbt versions     | snowplow-web version |
 | :--------------------------------------------------: | :-----------------: | :------------------: |
-| BigQuery, Databricks, Redshift, Snowflake & Postgres |  >=1.3.0 to <2.0.0  |        0.13.0         |
+| BigQuery, Databricks, Redshift, Snowflake & Postgres |  >=1.3.0 to <2.0.0  |        0.13.1         |
 | BigQuery, Databricks, Redshift, Snowflake & Postgres |  >=1.0.0 to <1.3.0  |        0.11.0         |
 |       BigQuery, Redshift, Snowflake & Postgres       | >=0.20.0 to <1.0.0  |        0.5.1         |
 |            BigQuery, Redshift & Snowflake            | >=0.18.0 to <0.20.0 |        0.4.1         |

--- a/custom_example/dbt_project.yml
+++ b/custom_example/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_custom_example'
-version: '0.13.0'
+version: '0.13.1'
 config-version: 2
 
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -44,6 +44,7 @@ vars:
     snowplow__ua_bot_filter: true
     snowplow__derived_tstamp_partitioned: true
     snowplow__session_stitching: true
+    snowplow__enable_load_tstamp: true # set to false if you are using the postgres loader or earlier than 4.0.0 of the RDB loader
     # Variables - Advanced Config
     snowplow__lookback_window_hours: 6
     snowplow__session_lookback_days: 730

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_web'
-version: '0.13.0'
+version: '0.13.1'
 config-version: 2
 
 require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_web_integration_tests'
-version: '0.13.0'
+version: '0.13.1'
 config-version: 2
 
 profile: 'integration_tests'

--- a/models/base/scratch/default/snowplow_web_base_events_this_run.sql
+++ b/models/base/scratch/default/snowplow_web_base_events_this_run.sql
@@ -143,7 +143,9 @@ with events_this_run AS (
     a.event_version,
     a.event_fingerprint,
     a.true_tstamp,
-    a.load_tstamp,
+    {% if var('snowplow__enable_load_tstamp', true) %}
+      a.load_tstamp,
+    {% endif %}
     dense_rank() over (partition by a.event_id order by a.collector_tstamp) as event_id_dedupe_index --dense_rank so rows with equal tstamps assigned same number
 
   from {{ var('snowplow__events') }} as a


### PR DESCRIPTION
## Description & motivation
This is a patch release with the purpose to unblock those Redshift/Postgres users whose loaders do not send `load_tstamp` field to their events table: they use `Postgres loader` or `RDB Loader` below v4.0.0. Please note that they will not be able to use the Consent models but the general web model will still be supported.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 

