### PR TITLE
Fix whitespace issue on redshift sessions (Close #166)

### DIFF
--- a/models/sessions/scratch/default/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/default/snowplow_web_sessions_this_run.sql
@@ -104,7 +104,7 @@ with session_firsts as (
     {% if var('snowplow__enable_yauaa', false) -%}
         left join {{ ref('snowplow_web_pv_yauaa') }} ya
         on ev.page_view_id = ya.page_view_id
-    {%- endif -%}
+    {% endif -%}
 
     where
         ev.event_name in ('page_ping', 'page_view')


### PR DESCRIPTION
## Description & motivation
Fixes an issue where when YAUAA is enabled the whitespace cutting means that the `where` clause is not 

I am going to raise a follow-on issue to add to add those contexts to the integration tests so we can catch these in the future.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
