### PR TITLE
Feature/custom and consent migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dbt_packages/
 logs/
 .DS_Store
 dbt-service-account.json
+.vscode/settings.json

--- a/custom_example/README.md
+++ b/custom_example/README.md
@@ -2,7 +2,7 @@
 
 This is a dummy dbt project demonstrating how to integrate custom modules into the Snowplow Web dbt package.
 
-We demonstrate two methods to add custom modules.
+We demonstrate two methods to add custom modules, but more details are provided in our [docs](https://docs.snowplow.io/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/).
 
 ## Set Up
 
@@ -43,7 +43,7 @@ An example of such a set up for Redshift can be seen in [snowplow_web_pv_channel
 - We select events from `snowplow_web_base_events_this_run` rather than `atomic.events`. This ensures we only have the events required for this run, as well as not having to worry about de-duping events.
 - We restrict the date range of the `com_snowplowanalytics_snowplow_link_click_1` source table using `snowplow_web_base_new_event_limits`, improving query performance. This is only required in Redshift due to the federated table design.
 - We include the `is_run_with_new_events()` macro in the where clause. This ensures that no old data is inserted into the table during back-fills. This improves performance and protects against inaccurate data in the table during batched back-fills.
-- The model is materialized using the `snowplow_incremental` materialization. This reduces the table scan on the target table during the upsert procedure. You could equally use the out-the-box `incremental` materialization if you so wanted.
+- The model is materialized using the `incremental` materialization with the `snowplow_optimize` config. This reduces the table scan on the target table during the upsert procedure. 
 - This incremental table can then be joined back to the `snowplow_web_page_views` table to produce a bespoke page views view catered for your business needs, `snowplow_page_views_custom`. Notice how this is materialized as a view, saving on storage cost.
 
 ## Method 2 - Replace a standard derived table with your own custom version

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/bigquery/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/bigquery/snowplow_web_pv_channel_engagement.sql
@@ -1,15 +1,16 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
     }),
-  ) 
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/databricks/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/databricks/snowplow_web_pv_channel_engagement.sql
@@ -1,12 +1,13 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
-    partition_by = snowplow_utils.get_partition_by(databricks_partition_by='start_tstamp_date')
-  ) 
+    partition_by = snowplow_utils.get_partition_by(databricks_val='start_tstamp_date'),
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/default/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/default/snowplow_web_pv_channel_engagement.sql
@@ -1,13 +1,14 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
-    dist='page_view_id'
-  ) 
+    dist='page_view_id',
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/snowflake/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/snowflake/snowplow_web_pv_channel_engagement.sql
@@ -1,13 +1,14 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     cluster_by=snowplow_web.web_cluster_by_fields_page_views(),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
-  ) 
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/sessions/snowplow_web_sessions_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/sessions/snowplow_web_sessions_custom.sql
@@ -1,21 +1,22 @@
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='domain_sessionid',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='domain_sessionid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_sessions(),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
-  ) 
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    snowplow_optimize= true
+  )
 }}
 
 
-select 
+select
   s.*,
   {% if target.type in ['databricks', 'spark'] -%}
   , DATE(start_tstamp) as start_tstamp_date

--- a/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
@@ -1,16 +1,17 @@
 {{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='user_primary_key',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='user_primary_key',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_users(),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    snowplow_optimize=true
   )
 }}
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -56,7 +56,6 @@ vars:
     snowplow__max_session_days: 3
     snowplow__upsert_lookback_days: 30
     snowplow__query_tag: "snowplow_dbt"
-    snowplow__incremental_materialization: "incremental"
     snowplow__dev_target_name: 'dev'
     snowplow__allow_refresh: false
     # snowplow__limit_page_views_to_session: true

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -4,6 +4,10 @@ config-version: 2
 
 profile: 'integration_tests'
 
+dispatch:
+  - macro_namespace: dbt
+    search_order: ['snowplow_utils', 'dbt']
+
 model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]

--- a/integration_tests/models/dummy_custom_module/snowplow_web_pv_channels.sql
+++ b/integration_tests/models/dummy_custom_module/snowplow_web_pv_channels.sql
@@ -1,16 +1,17 @@
 {{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     enabled=var('snowplow__enable_custom_example'),
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='page_view_id',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }),
-    cluster_by=["page_view_id"]
+    cluster_by=["page_view_id"],
+    snowplow_optimize=true
   )
 }}
 

--- a/macros/cluster_by_fields.sql
+++ b/macros/cluster_by_fields.sql
@@ -6,7 +6,7 @@
 
 {% macro default__web_cluster_by_fields_sessions_lifecycle() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["session_id"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -19,7 +19,7 @@
 
 {% macro default__web_cluster_by_fields_page_views() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["domain_userid","domain_sessionid"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["domain_userid","domain_sessionid"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -32,7 +32,7 @@
 
 {% macro default__web_cluster_by_fields_sessions() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["domain_userid"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["domain_userid"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -45,7 +45,7 @@
 
 {% macro default__web_cluster_by_fields_users() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["user_id","domain_userid"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["user_id","domain_userid"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -57,6 +57,6 @@
 
 {% macro default__web_cluster_by_fields_consent() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["event_id","domain_userid"], snowflake_cols=["to_date(load_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["event_id","domain_userid"], snowflake_val=["to_date(load_tstamp)"])) }}
 
 {% endmacro %}

--- a/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
+++ b/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
@@ -20,7 +20,7 @@ This significantly reduces table scans
 
 with prep as (
   select
-    cast(null as {{ snowplow_utils.type_string(64) }}) session_id
+    cast(null as {{ type_string() }}) session_id
 )
 
 select *

--- a/models/base/manifest/snowplow_web_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/snowplow_web_base_sessions_lifecycle_manifest.sql
@@ -1,14 +1,14 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='session_id',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_sessions_lifecycle(),
     full_refresh=snowplow_web.allow_refresh(),
     tags=["manifest"],
@@ -53,7 +53,7 @@ with new_events_session_ids as (
   group by 1
   )
 
-{% if snowplow_utils.snowplow_is_incremental() %}
+{% if is_incremental() %}
 
 , previous_sessions as (
   select *

--- a/models/base/manifest/snowplow_web_incremental_manifest.sql
+++ b/models/base/manifest/snowplow_web_incremental_manifest.sql
@@ -15,7 +15,7 @@
 
 with prep as (
   select
-    cast(null as {{ snowplow_utils.type_string(4096) }}) model,
+    cast(null as {{ snowplow_utils.type_max_string() }}) model,
     cast('1970-01-01' as {{ type_timestamp() }}) as last_success
 )
 

--- a/models/optional_modules/consent/snowplow_web_consent_log.sql
+++ b/models/optional_modules/consent/snowplow_web_consent_log.sql
@@ -1,21 +1,22 @@
 {{
   config(
-    materialized= var("snowplow__incremental_materialization", 'snowplow_incremental'),
+    materialized= 'incremental',
     unique_key='event_id',
     upsert_date_key='derived_tstamp',
     sort='derived_tstamp',
     dist='event_id',
     tags=["derived"],
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "derived_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by = 'derived_tstamp_date'),
+    }, databricks_val = 'derived_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_consent(),
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    }
+    },
+    snowplow_optimize= true
   )
 }}
 

--- a/models/page_views/snowplow_web_page_views.sql
+++ b/models/page_views/snowplow_web_page_views.sql
@@ -1,14 +1,14 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='page_view_id',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_page_views(),
     tags=["derived"],
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),

--- a/models/sessions/scratch/bigquery/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/bigquery/snowplow_web_sessions_this_run.sql
@@ -20,9 +20,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/scratch/databricks/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/databricks/snowplow_web_sessions_this_run.sql
@@ -20,9 +20,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/scratch/default/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/default/snowplow_web_sessions_this_run.sql
@@ -20,9 +20,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/scratch/snowflake/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/snowflake/snowplow_web_sessions_this_run.sql
@@ -21,9 +21,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/snowplow_web_sessions.sql
+++ b/models/sessions/snowplow_web_sessions.sql
@@ -1,14 +1,14 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='domain_sessionid',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='domain_sessionid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_sessions(),
     tags=["derived"],
     post_hook="{{ snowplow_web.stitch_user_identifiers(

--- a/models/user_mapping/snowplow_web_user_mapping.sql
+++ b/models/user_mapping/snowplow_web_user_mapping.sql
@@ -4,7 +4,7 @@
     unique_key='domain_userid',
     sort='end_tstamp',
     dist='domain_userid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "end_tstamp",
       "data_type": "timestamp"
     }),

--- a/models/users/scratch/snowplow_web_users_aggs.sql
+++ b/models/users/scratch/snowplow_web_users_aggs.sql
@@ -1,10 +1,10 @@
 {{
   config(
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }),
-    cluster_by=snowplow_utils.get_cluster_by(bigquery_cols=["domain_userid"]),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["domain_userid"]),
     sort='domain_userid',
     dist='domain_userid',
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))

--- a/models/users/snowplow_web_users.sql
+++ b/models/users/snowplow_web_users.sql
@@ -1,15 +1,15 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='domain_userid',
     upsert_date_key='start_tstamp',
     disable_upsert_lookback=true,
     sort='start_tstamp',
     dist='domain_userid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_users(),
     tags=["derived"],
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: 0.14.0-rc1
+    version: 0.14.0-rc2

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
-  - package: snowplow/snowplow_utils
-    version: 0.14.0-rc2
+  # - package: snowplow/snowplow_utils
+  #   version: 0.14.0-rc2
+  - git: "https://github.com/snowplow/dbt-snowplow-utils.git" # git URL
+    revision: feature/tests-and-incrementals


### PR DESCRIPTION
## Description & motivation
1. Take all consent and custom models and change them to also use the new materialization approach, updating examples.
2. Swap out any utils string type with a length less than 256 for the default, and any greater specifically to the max length type.
3. Replace calls to `get_partition_by` and `get_cluster_by` with calls to `get_value_by_target_type` instead.

Relates to https://github.com/snowplow/dbt-snowplow-utils/pull/121

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)


