### PR TITLE
Release/snowplow web/0.14.0-rc2

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -62,7 +62,7 @@ jobs:
         working-directory: ./integration_tests
     strategy:
       matrix:
-        dbt_version: ["1.*"]
+        dbt_version: ["1.4.*"]
         warehouse: ["snowflake"]
 
 
@@ -110,9 +110,11 @@ jobs:
         rm -f ../docs/catalog.json
         rm -f ../docs/manifest.json
         rm -f ../docs/run_results.json
+        rm -f ../docs/index.html
         cp target/catalog.json ../docs/catalog.json
         cp target/manifest.json ../docs/manifest.json
         cp target/run_results.json ../docs/run_results.json
+        cp target/index.html ../docs/index.html
         dbt run-operation post_ci_cleanup --target ${{ matrix.warehouse }}
 
     - name: Commit & Push changes
@@ -123,7 +125,7 @@ jobs:
         # - user_info -> Your Display Name <your-actual@email.com>
         # - github_actions -> github-actions <email associated with the github logo>
         # Default: github_actor
-        add: ./docs/catalog.json ./docs/manifest.json ./docs/run_results.json
+        add: ./docs/catalog.json ./docs/manifest.json ./docs/run_results.json ./docs/index.html
         default_author: github_actions
         message: 'Update dbt docs'
         new_branch: gh_pages

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dbt_packages/
 logs/
 .DS_Store
 dbt-service-account.json
+.vscode/settings.json

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,29 @@
+snowplow-web 0.14.0-rc2 (2023-03-10)
+---------------------------------------
+## Summary
+**This is a pre-release version of the package, we believe it to be in working condition but you may encounter bugs and some features may change before the final release.**
+
+This version migrates the rest of our models (consent and custom examples) to the new materialization, and uses new macros in place of those we have deprecated.
+
+As a reminder Users will need to add the following to their `dbt_project.yml` to benefit from the enhancements: 
+```yaml
+# dbt_project.yml
+...
+dispatch:
+  - macro_namespace: dbt
+    search_order: ['snowplow_utils', 'dbt']
+```
+
+For custom models and more details, please refer to our temporary docs page: https://docs.snowplow.io/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-advanced-usage/dbt-incremental-logic-pre-release/ 
+
+## Features
+Migrate from `get_cluster_by` and `get_partition_by` to `get_value_by_target_type`
+Migrate consent and custom models to use new materialization
+Remove `snowplow__incremental_materialization` variable
+## Docs
+Small typo fixes
+Small update to readme
+
 snowplow-web 0.14.0-rc1 (2023-03-06)
 ---------------------------------------
 ## Summary

--- a/custom_example/README.md
+++ b/custom_example/README.md
@@ -2,7 +2,7 @@
 
 This is a dummy dbt project demonstrating how to integrate custom modules into the Snowplow Web dbt package.
 
-We demonstrate two methods to add custom modules.
+We demonstrate two methods to add custom modules, but more details are provided in our [docs](https://docs.snowplow.io/docs/modeling-your-data/modeling-your-data-with-dbt/dbt-custom-models/).
 
 ## Set Up
 
@@ -43,7 +43,7 @@ An example of such a set up for Redshift can be seen in [snowplow_web_pv_channel
 - We select events from `snowplow_web_base_events_this_run` rather than `atomic.events`. This ensures we only have the events required for this run, as well as not having to worry about de-duping events.
 - We restrict the date range of the `com_snowplowanalytics_snowplow_link_click_1` source table using `snowplow_web_base_new_event_limits`, improving query performance. This is only required in Redshift due to the federated table design.
 - We include the `is_run_with_new_events()` macro in the where clause. This ensures that no old data is inserted into the table during back-fills. This improves performance and protects against inaccurate data in the table during batched back-fills.
-- The model is materialized using the `snowplow_incremental` materialization. This reduces the table scan on the target table during the upsert procedure. You could equally use the out-the-box `incremental` materialization if you so wanted.
+- The model is materialized using the `incremental` materialization with the `snowplow_optimize` config. This reduces the table scan on the target table during the upsert procedure. 
 - This incremental table can then be joined back to the `snowplow_web_page_views` table to produce a bespoke page views view catered for your business needs, `snowplow_page_views_custom`. Notice how this is materialized as a view, saving on storage cost.
 
 ## Method 2 - Replace a standard derived table with your own custom version

--- a/custom_example/dbt_project.yml
+++ b/custom_example/dbt_project.yml
@@ -1,7 +1,10 @@
 name: 'snowplow_custom_example'
-version: '0.13.2'
+version: '0.14.0-rc2'
 config-version: 2
 
+dispatch:
+  - macro_namespace: dbt
+    search_order: ['snowplow_utils', 'dbt']
 
 profile: 'default'
 

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/bigquery/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/bigquery/snowplow_web_pv_channel_engagement.sql
@@ -1,15 +1,16 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
     }),
-  ) 
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/databricks/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/databricks/snowplow_web_pv_channel_engagement.sql
@@ -1,12 +1,13 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
-    partition_by = snowplow_utils.get_partition_by(databricks_partition_by='start_tstamp_date')
-  ) 
+    partition_by = snowplow_utils.get_partition_by(databricks_val='start_tstamp_date'),
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/default/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/default/snowplow_web_pv_channel_engagement.sql
@@ -1,13 +1,14 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
-    dist='page_view_id'
-  ) 
+    dist='page_view_id',
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/snowflake/snowplow_web_pv_channel_engagement.sql
+++ b/custom_example/models/snowplow_web_custom_modules/page_views/page_view_channel_engagement/snowflake/snowplow_web_pv_channel_engagement.sql
@@ -1,13 +1,14 @@
---Using `snowplow_incremental` materialization to reduce table scans. Could also use the standard `incremental` materialization.
+--Using `snowplow_optimize` config to reduce table scans. Could also use the standard `incremental` materialization.
 
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     cluster_by=snowplow_web.web_cluster_by_fields_page_views(),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
-  ) 
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    snowplow_optimize=true
+  )
 }}
 
 with link_clicks as (

--- a/custom_example/models/snowplow_web_custom_modules/sessions/snowplow_web_sessions_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/sessions/snowplow_web_sessions_custom.sql
@@ -1,21 +1,22 @@
-{{ 
+{{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='domain_sessionid',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='domain_sessionid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_sessions(),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
-  ) 
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    snowplow_optimize= true
+  )
 }}
 
 
-select 
+select
   s.*,
   {% if target.type in ['databricks', 'spark'] -%}
   , DATE(start_tstamp) as start_tstamp_date

--- a/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
+++ b/custom_example/models/snowplow_web_custom_modules/users/snowplow_web_users_custom.sql
@@ -1,16 +1,17 @@
 {{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     unique_key='user_primary_key',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='user_primary_key',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_users(),
-    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
+    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
+    snowplow_optimize=true
   )
 }}
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -56,7 +56,6 @@ vars:
     snowplow__max_session_days: 3
     snowplow__upsert_lookback_days: 30
     snowplow__query_tag: "snowplow_dbt"
-    snowplow__incremental_materialization: "incremental"
     snowplow__dev_target_name: 'dev'
     snowplow__allow_refresh: false
     # snowplow__limit_page_views_to_session: true

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_web'
-version: '0.14.0-rc1'
+version: '0.14.0-rc2'
 config-version: 2
 
 require-dbt-version: [">=1.4.0", "<2.0.0"]

--- a/docs/markdown/snowplow_web_macros_docs.md
+++ b/docs/markdown/snowplow_web_macros_docs.md
@@ -61,7 +61,7 @@ and not rlike(useragent, '.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit
 {% docs macro_stitch_user_identifiers %}
 {% raw %}		
 This macro is used as a post-hook on the sessions table to stitch user identities using the user_mapping table provided.
-- 
+
 #### Returns
 
 The update/merge statement to update the `stitched_user_id` column, if enabled.
@@ -71,7 +71,7 @@ The update/merge statement to update the `stitched_user_id` column, if enabled.
 {% docs macro_get_iab_context_fields %}
 {% raw %}		
 This macro is used to extract the fields from the iab enrichment context for each warehouse.
-- 
+
 #### Returns
 
 The sql to extract the columns from the iab context, or these columns as nulls.
@@ -81,7 +81,7 @@ The sql to extract the columns from the iab context, or these columns as nulls.
 {% docs macro_get_ua_context_fields %}
 {% raw %}		
 This macro is used to extract the fields from the ua enrichment context for each warehouse.
-- 
+
 #### Returns
 
 The sql to extract the columns from the ua context, or these columns as nulls.
@@ -91,7 +91,7 @@ The sql to extract the columns from the ua context, or these columns as nulls.
 {% docs macro_get_yauaa_context_fields %}
 {% raw %}		
 This macro is used to extract the fields from the yauaa enrichment context for each warehouse.
-- 
+
 #### Returns
 
 The sql to extract the columns from the yauaa context, or these columns as nulls.
@@ -101,7 +101,7 @@ The sql to extract the columns from the yauaa context, or these columns as nulls
 {% docs macro_web_cluster_by_X %}
 {% raw %}		
 This macro is used to return the appropriate `cluster_by` fields for the table, depending on the warehouse target.
-- 
+
 #### Returns
 
 The specific fields for each warehouse (see macro code for values).
@@ -111,7 +111,7 @@ The specific fields for each warehouse (see macro code for values).
 {% docs macro_bq_context_fields %}
 {% raw %}		
 This macro is used to return the appropriate field and type mapping for use in `snowplow_utils.get_optional_fields`.
-- 
+
 #### Returns
 
 The specific fields and their type for the context (see macro code for values).
@@ -121,7 +121,7 @@ The specific fields and their type for the context (see macro code for values).
 {% docs macro_allow_refresh %}
 {% raw %}		
 This macro is used to determine if a full-refresh is allowed (depending on the environment), using the `snowplow__allow_refresh` variable.
-- 
+
 #### Returns
 `snowplow__allow_refresh` if environment is not `dev`, `none` otherwise.
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -4,6 +4,10 @@ config-version: 2
 
 profile: 'integration_tests'
 
+dispatch:
+  - macro_namespace: dbt
+    search_order: ['snowplow_utils', 'dbt']
+
 model-paths: ["models"]
 analysis-paths: ["analysis"]
 test-paths: ["tests"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowplow_web_integration_tests'
-version: '0.14.0-rc1'
+version: '0.14.0-rc2'
 config-version: 2
 
 profile: 'integration_tests'

--- a/integration_tests/models/dummy_custom_module/snowplow_web_pv_channels.sql
+++ b/integration_tests/models/dummy_custom_module/snowplow_web_pv_channels.sql
@@ -1,16 +1,17 @@
 {{
   config(
-    materialized='snowplow_incremental',
+    materialized='incremental',
     enabled=var('snowplow__enable_custom_example'),
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='page_view_id',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }),
-    cluster_by=["page_view_id"]
+    cluster_by=["page_view_id"],
+    snowplow_optimize=true
   )
 }}
 

--- a/macros/cluster_by_fields.sql
+++ b/macros/cluster_by_fields.sql
@@ -6,7 +6,7 @@
 
 {% macro default__web_cluster_by_fields_sessions_lifecycle() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["session_id"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["session_id"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -19,7 +19,7 @@
 
 {% macro default__web_cluster_by_fields_page_views() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["domain_userid","domain_sessionid"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["domain_userid","domain_sessionid"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -32,7 +32,7 @@
 
 {% macro default__web_cluster_by_fields_sessions() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["domain_userid"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["domain_userid"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -45,7 +45,7 @@
 
 {% macro default__web_cluster_by_fields_users() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["user_id","domain_userid"], snowflake_cols=["to_date(start_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["user_id","domain_userid"], snowflake_val=["to_date(start_tstamp)"])) }}
 
 {% endmacro %}
 
@@ -57,6 +57,6 @@
 
 {% macro default__web_cluster_by_fields_consent() %}
 
-  {{ return(snowplow_utils.get_cluster_by(bigquery_cols=["event_id","domain_userid"], snowflake_cols=["to_date(load_tstamp)"])) }}
+  {{ return(snowplow_utils.get_value_by_target_type(bigquery_val=["event_id","domain_userid"], snowflake_val=["to_date(load_tstamp)"])) }}
 
 {% endmacro %}

--- a/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
+++ b/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
@@ -20,7 +20,7 @@ This significantly reduces table scans
 
 with prep as (
   select
-    cast(null as {{ snowplow_utils.type_string(64) }}) session_id
+    cast(null as {{ type_string() }}) session_id
 )
 
 select *

--- a/models/base/manifest/snowplow_web_base_sessions_lifecycle_manifest.sql
+++ b/models/base/manifest/snowplow_web_base_sessions_lifecycle_manifest.sql
@@ -1,14 +1,14 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='session_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='session_id',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_sessions_lifecycle(),
     full_refresh=snowplow_web.allow_refresh(),
     tags=["manifest"],
@@ -53,7 +53,7 @@ with new_events_session_ids as (
   group by 1
   )
 
-{% if snowplow_utils.snowplow_is_incremental() %}
+{% if is_incremental() %}
 
 , previous_sessions as (
   select *

--- a/models/base/manifest/snowplow_web_incremental_manifest.sql
+++ b/models/base/manifest/snowplow_web_incremental_manifest.sql
@@ -15,7 +15,7 @@
 
 with prep as (
   select
-    cast(null as {{ snowplow_utils.type_string(4096) }}) model,
+    cast(null as {{ snowplow_utils.type_max_string() }}) model,
     cast('1970-01-01' as {{ type_timestamp() }}) as last_success
 )
 

--- a/models/optional_modules/consent/snowplow_web_consent_log.sql
+++ b/models/optional_modules/consent/snowplow_web_consent_log.sql
@@ -1,21 +1,22 @@
 {{
   config(
-    materialized= var("snowplow__incremental_materialization", 'snowplow_incremental'),
+    materialized= 'incremental',
     unique_key='event_id',
     upsert_date_key='derived_tstamp',
     sort='derived_tstamp',
     dist='event_id',
     tags=["derived"],
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "derived_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by = 'derived_tstamp_date'),
+    }, databricks_val = 'derived_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_consent(),
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),
     tblproperties={
       'delta.autoOptimize.optimizeWrite' : 'true',
       'delta.autoOptimize.autoCompact' : 'true'
-    }
+    },
+    snowplow_optimize= true
   )
 }}
 

--- a/models/page_views/snowplow_web_page_views.sql
+++ b/models/page_views/snowplow_web_page_views.sql
@@ -1,14 +1,14 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='page_view_id',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='page_view_id',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by = {
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val = {
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_page_views(),
     tags=["derived"],
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),

--- a/models/sessions/scratch/bigquery/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/bigquery/snowplow_web_sessions_this_run.sql
@@ -20,9 +20,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/scratch/databricks/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/databricks/snowplow_web_sessions_this_run.sql
@@ -20,9 +20,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/scratch/default/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/default/snowplow_web_sessions_this_run.sql
@@ -20,9 +20,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/scratch/snowflake/snowplow_web_sessions_this_run.sql
+++ b/models/sessions/scratch/snowflake/snowplow_web_sessions_this_run.sql
@@ -21,9 +21,9 @@ with session_firsts as (
         domain_userid,
         {% if var('snowplow__session_stitching') %}
             -- updated with mapping as part of post hook on derived sessions table
-            cast(domain_userid as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(domain_userid as {{ type_string() }}) as stitched_user_id,
         {% else %}
-            cast(null as {{ snowplow_utils.type_string(255) }}) as stitched_user_id,
+            cast(null as {{ type_string() }}) as stitched_user_id,
         {% endif %}
         network_userid as network_userid,
 

--- a/models/sessions/snowplow_web_sessions.sql
+++ b/models/sessions/snowplow_web_sessions.sql
@@ -1,14 +1,14 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='domain_sessionid',
     upsert_date_key='start_tstamp',
     sort='start_tstamp',
     dist='domain_sessionid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_sessions(),
     tags=["derived"],
     post_hook="{{ snowplow_web.stitch_user_identifiers(

--- a/models/user_mapping/snowplow_web_user_mapping.sql
+++ b/models/user_mapping/snowplow_web_user_mapping.sql
@@ -4,7 +4,7 @@
     unique_key='domain_userid',
     sort='end_tstamp',
     dist='domain_userid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "end_tstamp",
       "data_type": "timestamp"
     }),

--- a/models/users/scratch/snowplow_web_users_aggs.sql
+++ b/models/users/scratch/snowplow_web_users_aggs.sql
@@ -1,10 +1,10 @@
 {{
   config(
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
     }),
-    cluster_by=snowplow_utils.get_cluster_by(bigquery_cols=["domain_userid"]),
+    cluster_by=snowplow_utils.get_value_by_target_type(bigquery_val=["domain_userid"]),
     sort='domain_userid',
     dist='domain_userid',
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))

--- a/models/users/snowplow_web_users.sql
+++ b/models/users/snowplow_web_users.sql
@@ -1,15 +1,15 @@
 {{
   config(
-    materialized=var("snowplow__incremental_materialization"),
+    materialized='incremental',
     unique_key='domain_userid',
     upsert_date_key='start_tstamp',
     disable_upsert_lookback=true,
     sort='start_tstamp',
     dist='domain_userid',
-    partition_by = snowplow_utils.get_partition_by(bigquery_partition_by={
+    partition_by = snowplow_utils.get_value_by_target_type(bigquery_val={
       "field": "start_tstamp",
       "data_type": "timestamp"
-    }, databricks_partition_by='start_tstamp_date'),
+    }, databricks_val='start_tstamp_date'),
     cluster_by=snowplow_web.web_cluster_by_fields_users(),
     tags=["derived"],
     sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt')),

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: 0.14.0-rc1
+    version: 0.14.0-rc2


### PR DESCRIPTION
## Description & motivation
Release second release candidate for web. Covers removing deprecated macros and new mat on consent and custom models. Also tweaks pages action to use new index file.

Will fail tests until the utils release is on the hub, will run again once it's there.

## Release Only Checklist
- [x] I have updated the version number in all relevant places
- [x] I have updated the CHANGELOG.md 

