### PR TITLE
Hard-lock redshift size, re-add databricks tests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         dbt_version: ["1.*"]
-        warehouse: ["postgres", "bigquery", "snowflake"] # TODO: Add RS self-hosted runner
+        warehouse: ["postgres", "bigquery", "snowflake", "databricks"] # TODO: Add RS self-hosted runner
 
     services:
       postgres:

--- a/integration_tests/.scripts/integration_test.sh
+++ b/integration_tests/.scripts/integration_test.sh
@@ -10,7 +10,7 @@ do
   esac
 done
 
-declare -a SUPPORTED_DATABASES=("bigquery" "postgres" "redshift" "snowflake")
+declare -a SUPPORTED_DATABASES=("bigquery" "postgres" "databricks" "redshift" "snowflake")
 
 # set to lower case
 DATABASE="$(echo $DATABASE | tr '[:upper:]' '[:lower:]')"

--- a/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
+++ b/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
@@ -20,7 +20,7 @@ This significantly reduces table scans
 
 with prep as (
   select
-    cast(null as {{ snowplow_utils.type_max_string() }}) session_id
+    cast(null as {% if target.type == 'redshift' %} varchar(400) {% else %} {{snowplow_utils.type_max_string()}} {% endif %}) session_id
 )
 
 select *


### PR DESCRIPTION
## Description & motivation
I regret every trying to simplify this string length thing. For some reason on live data the current version fails in redshift (I can't get it to replicate in the int tests no matter what I try). This fixes that issue. Happy to go with a higher number if people think it is needed.

## Checklist
- [x] I have verified that these changes work locally - including redshift
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [ ] Is your change a breaking change?

