### PR TITLE
Feature/add package name to limits log

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         dbt_version: ["1.*"]
-        warehouse: ["postgres", "bigquery", "snowflake"] # TODO: Add RS self-hosted runner
+        warehouse: ["postgres", "bigquery", "snowflake", "databricks"] # TODO: Add RS self-hosted runner
 
     services:
       postgres:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+snowplow-web 0.15.1 (2023-07-XX)
+---------------------------------------
+## Summary
+This version contains a fix for Redshift users based on a default column size, and adds the package name to the run limits log. Note the `snowplow_utils` minimum version has now increased to 0.14.3.
+
+## Features
+- Added package name to run limits log message
+## Fixes
+- Fix issue with new runs of Redshift due to default column size.
+
+## Upgrading
+Bump the snowplow-web version in your `packages.yml` file.
+
 snowplow-web 0.15.0 (2023-06-21)
 ---------------------------------------
 ## Summary

--- a/integration_tests/.scripts/integration_test.sh
+++ b/integration_tests/.scripts/integration_test.sh
@@ -10,7 +10,7 @@ do
   esac
 done
 
-declare -a SUPPORTED_DATABASES=("bigquery" "postgres" "redshift" "snowflake")
+declare -a SUPPORTED_DATABASES=("bigquery" "postgres" "databricks" "redshift" "snowflake")
 
 # set to lower case
 DATABASE="$(echo $DATABASE | tr '[:upper:]' '[:lower:]')"

--- a/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
+++ b/models/base/manifest/snowplow_web_base_quarantined_sessions.sql
@@ -20,7 +20,7 @@ This significantly reduces table scans
 
 with prep as (
   select
-    cast(null as {{ snowplow_utils.type_max_string() }}) session_id
+    cast(null as {% if target.type == 'redshift' %} varchar(400) {% else %} {{snowplow_utils.type_max_string()}} {% endif %}) session_id
 )
 
 select *

--- a/models/base/scratch/snowplow_web_base_new_event_limits.sql
+++ b/models/base/scratch/snowplow_web_base_new_event_limits.sql
@@ -1,5 +1,5 @@
 {{ config(
-   post_hook=["{{snowplow_utils.print_run_limits(this)}}"],
+   post_hook=["{{snowplow_utils.print_run_limits(this, 'snowplow_web')}}"],
    sql_header=snowplow_utils.set_query_tag(var('snowplow__query_tag', 'snowplow_dbt'))
    )
 }}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: snowplow/snowplow_utils
-    version: [">=0.14.2", "<0.15.0"]
+    version: [">=0.14.3", "<0.15.0"]


### PR DESCRIPTION
## Description & motivation
Adds package name to the log, doing this as it was requested by a user on the ecommerce package but we already have an open release branch for web so adding it to the upcoming release. I don't think it's technically a breaking change as we are only upping the minimum package version of utils, by a patch number.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Will do for release)
- [?] Is your change a breaking change?

