### PR TITLE
Fix github pages

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -62,7 +62,7 @@ jobs:
         working-directory: ./integration_tests
     strategy:
       matrix:
-        dbt_version: ["1.4.*"]
+        dbt_version: ["1.5.*"]
         warehouse: ["snowflake"]
 
 
@@ -104,9 +104,9 @@ jobs:
     - name: Create dbt docs
       run: |
         dbt run-operation post_ci_cleanup --target ${{ matrix.warehouse }}
-        dbt seed --target ${{matrix.warehouse}} --full-refresh
-        dbt run --target ${{matrix.warehouse}} --full-refresh --vars '{snowplow__allow_refresh: true, snowplow__backfill_limit_days: 243, snowplow__enable_cwv: false}'
-        dbt docs generate
+        dbt seed --full-refresh --target ${{matrix.warehouse}} 
+        dbt run --full-refresh --vars '{snowplow__allow_refresh: true, snowplow__backfill_limit_days: 243, snowplow__enable_cwv: false}' --target ${{matrix.warehouse}} 
+        dbt docs generate --vars '{snowplow__atomic_schema: null}' --target ${{matrix.warehouse}}
         rm -f ../docs/catalog.json
         rm -f ../docs/manifest.json
         rm -f ../docs/run_results.json


### PR DESCRIPTION
## Description & motivation
Because of the new way we use the dyanmically generated schema name in the integration tests, this breaks the docs because docs parsing is done slightly differently (it doesn't seem to render the jinja in the same way). 

This is not a problem with the package, because you really shouldn't be using jinja in your project yaml anyway (especially to set a schema!) we are just using it as a hack. If this is a problem long term we can fix it by removing the variable and doing the same `if` based on `project_name` that we do in e.g. ecommerce, just need to set it on the source and then whenever we use the atomic schema variable (the manifest and events this run models), but this makes those models a bit messier and moves our "testing" more into the main package models which I don't like.

As it's just an action, should be able to merge straight to main

This seems to be a working fix 

# Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have raised a [documentation](https://github.com/snowplow/documentation) PR if applicable (Link here if required)
- [ ] Is your change a breaking change?

